### PR TITLE
Move to standards track

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -1,7 +1,7 @@
 ---
 title: "Proposal for an Opt-Out Vocabulary"
 abbrev: "Opt-Out Vocab"
-category: info
+category: std
 
 docname: draft-ietf-aipref-vocab-latest
 submissiontype: IETF


### PR DESCRIPTION
In looking through the draft and the scope of this work item, it seems like this work is going to have to define something concrete.  That is, any attachment draft (which will be a protocol for real) will need to normatively reference this document in order for it to make sense.  In that spirit, I think that we need this to be a standards-track document, not an informational document.

Changing the intended status here will make all that possible.