### PR TITLE
Define an exemplary format

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -211,11 +211,12 @@ Systems referencing the vocabulary must not introduce additional categories that
 # Exemplary Serialization Format {#format}
 
 This section defines an exemplary serialization format for preferences.
-The format describes how the abstract model could be turned into a Unicode string or sequence of bytes.
+The format describes how the abstract model could be turned into Unicode text or sequence of bytes.
 
 The format relies on the Dictionary type defined in {{Section 3.2 of !FIELDS=RFC9651}}.
 The dictionary keys correspond to usage categories
-and the dictionary values correspond to explicit preferences.
+and the dictionary values correspond to explicit preferences,
+which can be either "y" or "n"; see {{y-or-n}}.
 
 For example, the following is a preference to allow AI training ({{ai}}),
 disallow generative AI training ({{genai}}), and
@@ -243,7 +244,7 @@ lowercase latin characters (a-z), digits (0-9), "_", "-", ".", or "*".
 These are encoded using the mappings in {{!ASCII=RFC0020}}.
 
 
-## Preference Labels
+## Preference Labels {#y-or-n}
 
 The abstract model used has two options for preferences associated with each category:
 allow and disallow.
@@ -332,7 +333,8 @@ ai=y, ai="n", genai=n, genai, tdm=n, tdm=()
 
 If the parsing of the Dictionary fails, no preferences are expressed.
 This includes where keys include uppercase characters,
-as this format is case sensitive.
+as this format is case sensitive
+(more correctly, it operates on bytes, not strings).
 
 
 ## Alternative Formats

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -315,7 +315,7 @@ as this format is case sensitive
 
 ## Alternative Formats
 
-This format is only a exemplary way to represent preferences.
+This format is only an exemplary way to represent preferences.
 The model described in {{model}}, can be used without this serialization.
 
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -208,7 +208,7 @@ The vocabulary does not preclude the use of other specific categories. Any state
 Systems referencing the vocabulary must not introduce additional categories that include existing categories defined in the vocabulary or otherwise include additional hierarchical relationships.
 
 
-# Serialization Format {#format}
+# Exemplary Serialization Format {#format}
 
 This section defines an exemplary serialization format for preferences.
 The format describes how the abstract model could be turned into a Unicode string or sequence of bytes.
@@ -248,7 +248,7 @@ These are encoded using the mappings in {{!ASCII=RFC0020}}.
 The abstract model used has two options for preferences associated with each category:
 allow and disallow.
 These are mapped to single byte Tokens ({{Section 3.3.4 of !FIELDS}})
-of "y" and "n", respectively (without the quotes).
+of `y` and `n`, respectively.
 
 
 ## Text Encoding
@@ -305,10 +305,10 @@ obtain the corresponding value from the collection,
 disregarding any parameters.
 A preference is assigned as follows:
 
-* If the value is a Token with a value of "y" (not including quotes),
+* If the value is a Token with a value of `y`,
   the associated preference is to allow that category of use.
 
-* If the value is a Token with a value of "n" (not including quotes),
+* If the value is a Token with a value of `n`,
   the associated preference is to disallow that category of use.
 
 * Otherwise, a preference is not expressed for that category of use.
@@ -337,7 +337,7 @@ as this format is case sensitive.
 
 ## Alternative Formats
 
-This format is only a recommended way to represent preferences.
+This format is only a exemplary way to represent preferences.
 The model described in {{model}}, can be used without this serialization.
 
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -192,7 +192,7 @@ The format describes how the abstract model could be turned into Unicode text or
 The format relies on the Dictionary type defined in {{Section 3.2 of !FIELDS=RFC9651}}.
 The dictionary keys correspond to usage categories
 and the dictionary values correspond to explicit preferences,
-which can be either "y" or "n"; see {{y-or-n}}.
+which can be either `y` or `n`; see {{y-or-n}}.
 
 For example, the following is a preference to allow AI training ({{ai}}),
 disallow generative AI training ({{genai}}), and
@@ -293,7 +293,7 @@ A preference is assigned as follows:
 Note that this last alternative includes
 the key being absent from the collection,
 values that are not Tokens,
-and Token values that are other than "y" or "n".
+and Token values that are other than `y` or `n`.
 All of these are not errors,
 they only result in no preference being inferred.
 


### PR DESCRIPTION
As discussed, we want to define a recommended format.  This executes on that.  It uses Structured Fields, which will ensure that we have a very easy translation to HTTP fields.  It also fits neatly into the other formats we are considering.

There are some interesting implications that are worth highlighting. The text I've added goes into some of that in more detail, but just to list them for visibility:

* This is a sequence of bytes, not a string.  That has implications for how it is included in some formats, but as RFC 9651 limits its syntax to a pretty small subset of the ASCII range, this is mostly just a theoretical consideration, not a practical one.

* Parsing errors in RFC 9651 means that you lose everything.  No preference survives.  That means that authoring errors have consequences.  This is an artifact of the format being more of a computer-to-computer language, rather than being tolerant of human error.  I'm not thrilled with this, but recognize the trade-off involved.

* Repeated keys mean that only the last one is taken.  Again, not thrilled with this, but think that the trade is tolerable.

* Labels are lowercase only.  A lot of the list traffic has started to use "AI=whatever"; RFC 9651 doesn't let us shout.  I think that this is fine, but it's another minor ding.

* Some patterns of use that might be natural are invalid.  For instance, spaces around the "=" is invalid, so "ai = n" would result in a parsing error and no preference being registered.

Closes #8.