### PR TITLE
Remove opt-out from the title

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -1,6 +1,6 @@
 ---
-title: "Proposal for an Opt-Out Vocabulary"
-abbrev: "Opt-Out Vocab"
+title: "A Vocabulary For Expressing AI Usage Preferences"
+abbrev: "AI Preferences"
 category: std
 
 docname: draft-ietf-aipref-vocab-latest


### PR DESCRIPTION
The changes we made to introductory text didn't catch the title, which now looks very wrong.

Happy to have this wordsmithed.  This is just the best I could come up with.