### PR TITLE
Switch to using aasvg for the diagram

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -114,53 +114,25 @@ in one of three states: "allowed", "disallowed", or "unknown".
 
 This section defines the categories of use in the vocabulary.
 
-The figure below shows the relationship between these categories:
+{{f-categories}} shows the relationship between these categories:
 
-<figure>
-<name>NMS View of Device State</name>
-<artset>
-<artwork type="svg">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="750" height="300" viewBox="0 0 750 300" text-anchor="middle" stroke-width="2" font-size="14" font-family="sans-serif">
-  <title>Opt-out vocabulary overview</title>
-
-  <!-- Outer Box -->
-  <rect x="50" y="50" width="630" height="220" rx="15" ry="15" fill="white" stroke="black"/>
-  <text x="365" y="80">Text and Data Mining</text>
-
-  <!-- AI Training Box -->
-  <rect x="80" y="100" width="380" height="130" rx="10" ry="10" fill="white" stroke="black" />
-  <text x="380" y="170">AI Training</text>
-
-  <!-- Generative AI Training Box -->
-  <rect x="110" y="130" width="200" height="70" rx="5" ry="5" fill="white" stroke="black" />
-  <text x="210" y="170">Generative AI Training</text>
-
-  <!-- Additional Use Cases Box -->
-  <rect x="500" y="100" width="150" height="130" class="dotted" rx="5" ry="5" fill="white" stroke="black" stroke-dasharray="5,5" />
-  <text x="575" y="160">[possibly]:</text>
-  <text x="575" y="180">additional use cases</text>
-</svg>
-
-</artwork>
-<artwork type="ascii-art">
-+--------------------------------------------------------------------------+
-|                                                                          |
-|                          Text and Data Mining (TDM)                      |
-|                                                                          |
-| +--------------------------------------------+  +- - - - - - - - - - -+  |
-| |  +--------------------------+              |  |                     |  |
-| |  |                          |              |                           |
-| |  |                          |              |  |    [possibly]:      |  |
-| |  | Generative AI Training   |  AI Training |                           |
-| |  |                          |              |  |  Other use cases    |  |
-| |  |                          |              |                           |
-| |  +--------------------------+              |  |                     |  |
-| +--------------------------------------------+  +- - - - - - - - - - -+  |
-|                                                                          |
-+--------------------------------------------------------------------------+
-</artwork>
-</artset>
-</figure>
+~~~ aasvg
+ .-------------------------------------------------.
+|                                                   |
+|               Text and Data Mining                |
+|                                                   |
+|   .-------------------------------------------.   |
+|  |                .------------------------.   |  |
+|  |               |                          |  |  |
+|  |               |                          |  |  |
+|  |  AI Training  |  Generative AI Training  |  |  |
+|  |               |                          |  |  |
+|  |               |                          |  |  |
+|  |                '------------------------'   |  |
+|   '-------------------------------------------'   |
+ '-------------------------------------------------'
+~~~
+{: #f-categories title="Relationship Between Categories of Use"}
 
 This list of specific use cases may be expanded in the future, should a consensus emerge between stakeholders, to include categories that address additional use cases as they emerge. In addition to these categories defined in the vocabulary, it is also expected that some systems implementing this vocabulary may extend this list with additional categories for their particular needs.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "aasvg": "^0.4.2"
+  }
+}


### PR DESCRIPTION
I've rearranged the diagram slightly to ensure that the categories are shown in the order we present them later.  I've also removed the "other" part, which didn't work that well otherwise.

This will get interesting when more items are added, but I have ideas on that front.

Sorry Paul, I destroyed your lovely hand-crafted SVG here.  I hope that's not an unacceptable loss.

[Preview the SVG here](https://ietf-wg-aipref.github.io/drafts/ascii-art/draft-ietf-aipref-vocab.html#f-categories)