### PR TITLE
Removed reference to origin of TDM definition

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -144,7 +144,7 @@ This list of specific use cases may be expanded in the future, should a consensu
 
 The act of using one or more assets in the context of any automated analytical technique aimed at analyzing text and data in digital form in order to generate information which includes but is not limited to patterns, trends and correlations.
 
-The use of assets for TDM is encompaases all the subsequent categories.
+The use of assets for TDM is encompasses all the subsequent categories.
 
 ## AI Training Category
 


### PR DESCRIPTION
This pull request proposes to leave the definition of TDM unchanged, but removes the explicit reference that this is based on EU law. This is part based on a review of existing legal definitions of TDM in other jurisdictions that have TDM exceptions in ether copyright law: 

The UK does not have a proper definition in the law itself, but the UK government provides on as part of its Guidance on Exceptions to copyright which is very similar to the EU definition: 

"Text and data mining is the use of automated analytical techniques to analyse text and data for patterns, trends and other useful information."

The other two jurisdictions with TDM exceptions that I am aware of (Singapore and Japan) do not use the term TDM. Instead they anchor the exceptions on “computational data analysis” (SG) or “data analysis (JP). 

Given this it seems sensible to keep the definition of TDM as unchanged.