### PR TITLE
Added inference category

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -158,6 +158,9 @@ The act of training General Purpose AI models that have the capacity to generate
 
 The use of assets for Generative AI Training is a proper subset of AI Training usage.
 
+## Inference Category
+
+To act of using one or more assets as input to a trained AI/ML model for the purposes of inferring a result.
 
 # Usage
 


### PR DESCRIPTION
This is a first attempt at a definition of the inference category. This is taken from the the C2PA's do not train assertion https://opensource.contentauthenticity.org/docs/manifest/assertions-actions#do-not-train-assertion and is based on their definition of `c2pa.ai_inference`. 

I would consider this to be a staring point for discussion and I do not have a strong attachment to the proposed language.