### PR TITLE
Add a description of how the model is interrogated

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -312,11 +312,85 @@ This includes where keys include uppercase characters,
 as this format is case sensitive
 (more correctly, it operates on bytes, not strings).
 
+This process produces an abstract data structure
+that assigns a preference to each usage category
+as described in {{model}}.
+
 
 ## Alternative Formats
 
 This format is only a exemplary way to represent preferences.
-The model described in {{model}}, can be used without this serialization.
+The model described in {{model}}
+can be used without this serialization.
+Any alternative format needs to define how that model is represented
+and how to generate the same model
+from any alternative representation.
+
+
+# Consulting a Preference Expression {#consulting}
+
+After processing a preference expression ({{processing}}),
+an application can request the status of a specific usage category.
+
+A single preference expression can be evaluated for a usage category
+as follows:
+
+1. If the expression contains an explicit preference
+   (either to allow or disallow),
+   that is the result.
+
+2. Otherwise, if the usage category is a proper subset
+   of another usage category,
+   recursively apply this process to that category
+   and use the result of that process.
+
+3. Otherwise, no preference is expressed.
+
+This process results in three potential answers:
+allow, disallow, and no preference.
+Applications can use the answer to guide their behavior.
+
+One approach for dealing with a "no preference" answer
+is to assign a default.
+This document takes no position on what default might be chosen
+as that will depend on policy constraints
+beyond the scope of this specification.
+
+
+## Combining Preferences {#combining}
+
+The application might have multiple preference expressions,
+obtained using different methods.
+
+If multiple preference expressions are active,
+all preference expressions are consulted ({{consulting}}),
+unless some can be discarded ({{overriding}}).
+This might result in conflicting answers.
+
+Absent some other means of resolving conflicts,
+the following process applies to each usage category:
+
+* If any preference expression indicates that the usage is disallowed,
+  the result is that the usage is disallowed.
+
+* Otherwise, if any preference preference allows the usage,
+  the result is that the usage is allowed.
+
+* Otherwise, no preference is expressed.
+
+This process ensures that the most restrictive preference applies.
+
+
+## Overriding Preferences {#overriding}
+
+Any method of attaching preference expressions to assets
+can specify conditions
+where the preferences obtained using one method
+override those of another method.
+
+If an application has two preference expressions
+where one is defined as overriding the other,
+the overridden preference can be discarded.
 
 
 # Security Considerations


### PR DESCRIPTION
This is stacked on top of #26.  It just shows the incremental change.  (If it is accepted and #26 is not, we'll lose it.  Be careful.)

Rather than describe how defaults apply as part of the processing algorithm, I've made that part of how the model is consulted.  This doesn't have any functional impact in this case; the result is the same either way.

The main decision this makes is about the order in which things apply:

1. within a single statement, the most-specific statement applies (i.e., `genai` overrides `ai`)
2. across multiple statements, the least-permissive statement of preference applies (i.e., `n` overrides `y`)

We'll need to discuss which model we want to follow and be deliberate about it.

An example should help.  Consider two statements of preference that include no preference for nested categories: `ai=n` and `genai=y`.

In the proposed approach, the more general answer from the first statement fills in an answer for the `genai` category.  That's the model that this change adopts.  The final, combined answer for `genai` is determined by the `ai=n` preference because the value from that statement is taken first and a disallow preference overrides an allow preference (absent other information; see the text).

In an alternative model, preferences could be combined before resolving any inherited preferences.  That is, items 1 and 2 above are swapped to:

1. across multiple statements, the least permissive statement of preference for each category is selected
2. then any category without an assigned preference inherits the preference of any less-specific category

In that case, we'd be saying that `ai=n` leaves `genai` unspecified deliberately to allow another preference to set `genai=y` if they prefer.  Only if no other entity expresses a preference, does the implied `genai=n` apply.  In that model, we'd be assuming that the entity that sets `ai=n` knows about `genai` and chooses to defer to others on what the preference is.

I personally dislike the alternative.  It makes any vocabulary extension fraught with issues.  Consider that an extension we define later might carve out space for a new specialized usage (like `inference`, if we were to define that in three years time, or `commercial` or anything else we might defer).  That would put an unexpected hole in any established preference.  Anyone who previously said no to a class of usage could have that preference overridden for that specialized usage.

Structuring the document this way allows us to make a decision between these a little more easily than if the "processing" in #26 filled in values for `genai` from the value of `ai`.

Finally, the last decision in the change is that attachment mechanisms can define that one statement can override another.

That opens the possibility of us choosing to have the HTTP header override robots.txt or even having content metadata override any other preferences.  If we find that this isn't needed, that's fine, but I understand that this is still on the table.  Including it cost me little effort; removing it would be equally easy.