### PR TITLE
Revise intent statement

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -67,7 +67,18 @@ It is designed to ensure that preference information can be exchanged between di
 The vocabulary is intended to govern the use of digital assets for the training of AI models and other forms of automated processing.
 It does not concern itself with the mechanisms involved in obtaining digital assets (i.e., crawling).
 
-The vocabulary is intended to work in contexts where such preferences result in legal obligations (such as rights reservations made by rightholders in jurisdictions with conditional TDM exceptions), and in contexts where this is not the case. It is without prejudice to applicable laws and the applicability of exceptions and limitations to copyright.
+
+The vocabulary is intended to be usable
+both where expressing preferences results in legal obligations
+and where there are no associated legal protections.
+That is, preferences can be expressed to invoke specific protections,
+or they can be made without any presumption of specific legal consequences.
+Potential legal obligations include rights reservations made by rightholders
+in jurisdictions with conditional exceptions on copyright protections.
+Expressing preferences is not intended to affect other rights over content,
+such as copyright or privacy protections,
+except as specifically mandated by applicable laws.
+
 
 # Conventions and Definitions
 


### PR DESCRIPTION
This was the hardest part of #31 and I think we could make this text clearer.  It is a bit too dense, even with what I'm proposing, but I hope that it's an improvement.

This is a version of the text provided by Timid Robot in https://github.com/ietf-wg-aipref/drafts/pull/31#discussion_r2100758813 with some additional edits, particularly the last sentence, where I think we need to be clear that:

1. This shouldn't prejudice decisions about other rights outside of the meaning of the preference itself.
2. The no prejudice piece applies even if the preferencing has legal effect, outside of the direct and obvious legal effect itself.
3. This isn't necessarily exclusively about copyright.  People have privacy rights over content that still apply, even if the preferences admit the possibility of use.

I think that this maintains the intent of the original, but I will admit that the original is dense enough that I might have lost some of the intent.