### PR TITLE
Update acknowledgments

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -505,10 +505,11 @@ Experts are expected to use input from that list to inform their decision.
 # Acknowledgments
 {:numbered="false"}
 
-The following individuals have been involved in the drafting of the proposal:
+The following individuals made significant contributions to this document:
 
-* Cullen Miller, Spawing.ai
-* Sebastian Posth, Liccium
-* Leonard Rosenthol, Adobe
-* Laurent Le Meur, EDRLab
-* Timid Robot Zehta, Creative Commons
+* {{{Cullen Miller}}}
+* {{{Laurent Le Meur}}}
+* {{{Leonard Rosenthol}}}
+* {{{Sebastian Posth}}}
+* {{{Timid Robot Zehta}}}
+{: spacing="compact"}


### PR DESCRIPTION
The IETF policy is that people participate as individuals, which means that we do not generally list affiliation when it comes to acknowledgments.  There's a carve-out for authorship and a few other things, but this is how we generally operate.

The formatting ensures that people can use their actual name.  Not a problem for these all-ASCII names, but it might end up being a problem later.

I've also sorted the list (by first name, which is my preferred approach once we have to deal with people who put family names first and all that).

There are probably a few other people that we might add here, though I want to be clear about the level of contribution before doing that. Both Brad and Felix have been very helpful on-list lately.