### PR TITLE
A reframing of search

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -178,8 +178,8 @@ The use of assets for Generative AI Training is a proper subset of AI Training u
 
 ## Search Category {#search}
 
-The act of using one or more assets to build a search index or as input to a trained AI/ML model that has the purpose of providing search results
-that include direct links to the location from where the asset was obtained.
+Using one or more assets in a search application that directs users to the location
+where those assets were obtained.
 
 The use of assets for AI Training is a proper subset of TDM usage.
 \[\[[Open issue](https://github.com/ietf-wg-aipref/drafts/issues/49)\]\]


### PR DESCRIPTION
As discussed on the list recently.

This does not include Brad's suggestion of "for the exclusive purpose of".  That is an important clarification, but I think we need to address that separately.  That is, we need to recognize that what we conceive of as "search" applications are more complicated than a simple index that is used to locate stuff.  We need commentary that explains that a single application can embody multiple usage categories and that use of assets for each of those aspects can have separate rules.  This isn't necessarily how those applications are built today[^1], but that's not necessarily a constraint on what we do.

[^1]: I am reminded of the concept of a "data lake", which has no distinction about where data has come from, the purpose for which it was obtained, or anything along those lines, making compliance with data protection regulation impossible.  The analogy here is with respect to use of assets for multiple purposes, without distinction.  For data lakes, the introduction of things like GDPR helped application developers build discipline about how they obtain and label personal information; perhaps this requires a similar shift, albeit one that affects a smaller set of people.