### PR TITLE
Tighten TDM language

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -160,7 +160,7 @@ This list of specific use cases may be expanded in the future, should a consensu
 
 ## Text and Data Mining (TDM) Category {#tdm}
 
-The act of using one or more assets in the context of any automated analytical technique aimed at analyzing text and data in digital form in order to generate information which includes but is not limited to patterns, trends and correlations.
+The act of using one or more assets in the context of automated processing aimed at analyzing text and data in order to generate information which includes but is not limited to patterns, trends and correlations.
 
 The use of assets for TDM encompasses all the subsequent categories.
 


### PR DESCRIPTION
Minor adjustments to the definition of TDM using more generic language, which further differentiates it from the definition provided in the EU Directive. (I have left the name of the category unchanged as changing that breaks lots of internal references, but I assume we will likely change the name as well)