### PR TITLE
Put "synthetic content" to the fore

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -172,7 +172,8 @@ The use of assets for AI Training is a proper subset of TDM usage.
 
 ## Generative AI Training Category {#genai}
 
-The act of training General Purpose AI models that have the capacity to generate text, images or other forms of synthetic content, or the act of training other types of AI models that have the purpose of generating text, images or other forms of synthetic content.
+The act of training AI models that are capable of generating synthetic content,
+which can be text, images, video, or any other form of content.
 
 The use of assets for Generative AI Training is a proper subset of AI Training usage.
 


### PR DESCRIPTION
The definition of generative AI training is about the generation of synthetic content.  This removes the distinction between foundational or general purpose models and those that are more specialized, because it focuses on whether the model with have the *capability* to generate content.