### PR TITLE
A more verbose search definition

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -264,7 +264,7 @@ Using one or more assets in a search application
 that directs users to the location
 from which the assets were retrieved.
 
-Search applications can be complex 
+Search applications can be complex
 and may serve multiple purposes.
 Only those parts of applications that direct users to the location of an asset
 are included in this category of use.


### PR DESCRIPTION
This keeps the short definition, but it expands it considerably to cover what seems to be the emerging perspective on the list.

This aims to do three things:

1. Narrow the definition to cover those cases that drive traffic to the original location of assets.

2. Ensure that this allows the use of AI in search applications, so that search preferences override AI use preferences.

3. To ensure that AI overviews, which act as a substitute for visiting the site, are excluded.

Obviously, there will continue to be things on the line.  The draft has text addressing the question of ambiguity.  As has been noted, the law has far better tools for managing that than technical specifications... if there is a dispute, that is.