### PR TITLE
Define AI and AI Training

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -99,8 +99,8 @@ This document uses the following terms:
 {: newline="true" spacing="compact"}
 Artificial Intelligence (AI):
 : Artificial Intelligence refers to an engineered system
-  that can, for a given set of human-defined objectives,
-  learn from data and generate outputs
+  that, for a given set of human-defined objectives,
+  learns from data to generate outputs
   such as content, predictions, recommendations, or decisions.
 
 AI Training:


### PR DESCRIPTION
This is a less hurried version of what I threw together during the sessions on Monday morning of the IETF meeting.

This draws on many definitions, primarily the one from Luciano Floridi in his commentary about the discussions between the EU and US: https://doi.org/10.1007/s13347-023-00690-z

That document includes a number of citations to legal definitions and other definitional work, including by the OECD, that were influential in coming to a definition.  I found a number of other sources, including the ITU definition mentioned in #100 (thanks to @taddhar for sharing that).

The definitions of AI Training and Machine Learning are a synthesis of much longer definitions by c3.ai and IBM, primarily. https://c3.ai/glossary/data-science/model-training/ https://www.ibm.com/think/topics/machine-learning

Closes #100.