### PR TITLE
Move vocabulary extensions

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -302,6 +302,14 @@ are not covered by this category of use.
 The use of assets for Search is a proper subset of Automated Processing usage.
 
 
+## Vocabulary Extensions {#vocab-extension}
+
+Systems referencing the vocabulary MUST NOT introduce additional categories
+that include existing categories defined in the vocabulary.
+That is, new categories of use can be defined as a subset of an existing category,
+but not a superset.
+
+
 # Usage {#usage}
 
 The vocabulary is used by referencing the terms defined in {{vocab}},
@@ -322,11 +330,6 @@ in two ways:
 
 For instance, a statement of preferences might indicate that the use of an asset is disallowed for AI Training.
 If arrangements, such as legal agreements, exist that explicitly permit the use of that asset, those arrangements likely apply, unless the terms of the arrangement explicitly say otherwise.
-
-
-## Vocabulary Extensions {#vocab-extension}
-
-Systems referencing the vocabulary MUST NOT introduce additional categories that include existing categories defined in the vocabulary or otherwise include additional hierarchical relationships.
 
 
 # Exemplary Serialization Format {#format}


### PR DESCRIPTION
Reword the statement; say it twice for clarity.

I considered adding more text here, even wrote out an example.  The example was convoluted and didn't help.  It even pointed to a way to manage the problem; an ugly way, but a way.  That was even more confusing.  A simple rule is best.