### PR TITLE
Remove "in the context of" from TDM language

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -261,7 +261,9 @@ This section defines the categories of use in the vocabulary.
 
 ## Automated Processing Category {#all}
 
-The act of using one or more assets in the context of automated processing aimed at analyzing text and data in order to generate information which includes but is not limited to patterns, trends and correlations.
+The act of using automated processing on one or more assets
+to analyze text and data in order to generate information
+which includes but is not limited to patterns, trends and correlations.
 
 The use of assets for automated processing encompasses all the subsequent categories.
 


### PR DESCRIPTION
The use of "in the context of" might be read to mean "in the vicinity of" or similar things that might make use of content by non-automated systems in scope for preferences at this very high level.  That was never the intent.

Rather than try to add words, shuffling them around to avoid the need for glue words between "automated processing", "assets", and "analysis" might be the best path out.  This now says:

> The act of using automated processing on one or more assets
> to analyze text and data in order to generate information [...]