### PR TITLE
Add "HTTP" to the title

### DIFF
--- a/draft-ietf-aipref-attach.md
+++ b/draft-ietf-aipref-attach.md
@@ -1,5 +1,5 @@
 ---
-title: "Associating AI Usage Preferences With Content"
+title: "Associating AI Usage Preferences with Content in HTTP"
 abbrev: "AI Preference Attachment"
 category: std
 


### PR DESCRIPTION
Today, I learned that the word "with" is not uniformly treated in title case guidance.  According to titlecaseconverter.com (what a world we live in) the Chicago Manual of Style has four letter prepositions presented in lowercase, so that's the one I'm using as I understand this to be the general guidebook for RFCs.  The split is basically 50/50 across different style guides for four-letter prepositions.

Closes #132.