### PR TITLE
Move from "expression" to "statement"

### DIFF
--- a/draft-ietf-aipref-attach.md
+++ b/draft-ietf-aipref-attach.md
@@ -80,7 +80,7 @@ such as distributors,
 might wish to express a preference
 regarding the types of usage they consider acceptable.
 Entities that might use that content
-need those preferences to be expressed
+need those preferences to be stated
 in a way that is easily consumed
 by an automated system.
 
@@ -100,19 +100,20 @@ these allow for the automated gathering of preferences
 in the same way that content is obtained.
 
 
-## Preference Expressions
+## Statements of Preference
 
-The format of preference expressions
+The format of a statement of preference
 is defined in the preference vocabulary {{VOCAB}}.
 The preference vocabulary defines:
 
-* what preferences can be expressed,
-* how multiple expressions of preference are combined, and
+* a model for associating usage preferences with categories of use,
+* some categories of use,
+* how multiple statements of preference are combined, and
 * how those preferences are turned into strings or byte sequences
   for use in a protocol.
 
 This document only defines how the strings or byte sequences are conveyed
-so that the preferences can be associated with content.
+so that statements of preference can be associated with content.
 
 
 ## Examples
@@ -239,7 +240,7 @@ The path might be absent or empty;
 if a path present,
 a SP or HTAB separates it from the usage preference.
 
-Note that the usage preference expression encoding
+Note that the statement of preference encoding
 does not use an ABNF definition,
 relying instead on the definitions in {{FIELDS}}.
 
@@ -311,15 +312,15 @@ indicates that the path is absent.
 
 If a path is specified,
 the path ends immediately before the first SP (U+20) or HTAB ("U+09") character.
-The remainder of the rule value is the usage preference expression.
+The remainder of the rule value is the statement of preference.
 If a path is absent,
-the entire rule value is the usage preference expression.
+the entire rule value is the statement of preference.
 
 The usage preference is encoded using the exemplary format
 defined in {{Section 6 of VOCAB}}.
 The parsing and processing rules from {{Sections 6 and 7 of VOCAB}} apply.
 
-Note that a usage preference expression is processed as a sequence of bytes,
+Note that a statement of preference is processed as a sequence of bytes,
 rather than Unicode text; see {{Section 6.3 of VOCAB}}.
 
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -135,13 +135,13 @@ to each of the categories of use in the vocabulary.
 Preferences regarding each category can be expressed
 either to allow or disallow the usage associated with the category.
 
-A statement of preferences can express preferences
+A statement of preferences can indicate preferences
 about some, all, or none of the categories from the vocabulary.
-This can mean that no preference is expressed for a given usage category.
+This can mean that no preference is stated for a given usage category.
 
 Some categories describe a proper subset of the usages of other categories.
-A preference that is expressed for the more general category applies
-if no preference is expressed for the more specific category.
+A preference that is stated for the more general category applies
+if no preference is stated for the more specific category.
 
 For example, the Automated Processing category might be assigned a preference that allows the associated usage.
 In the absence of any statement of preference regarding the AI Training category,
@@ -188,7 +188,7 @@ An entity that receives usage preferences MAY choose to respect
 those preferences it has discovered, according to
 an understanding of how the asset is used,
 how that usage corresponds to the usage categories
-where preferences have been expressed,
+where preferences have been stated,
 and the applicable legal context.
 
 Usage preferences can be overridden through express agreements
@@ -293,7 +293,7 @@ that are used to help users select between multiple candidate options.
 
 Preferences for the Search category apply to those parts of applications
 that provide search capabilities,
-regardless of what other preferences are expressed.
+regardless of what other preferences are stated.
 
 Parts of applications that do not direct users to the location of assets,
 such as summaries,
@@ -339,9 +339,9 @@ The dictionary keys correspond to usage categories
 and the dictionary values correspond to explicit preferences,
 which can be either `y` or `n`; see {{y-or-n}}.
 
-For example, the following expresses a preference to allow AI training ({{train-ai}}),
+For example, the following states a preference to allow AI training ({{train-ai}}),
 disallow generative AI training ({{train-genai}}), and
-and expresses no preference for other categories
+and states no preference for other categories
 other than subsets of these categories:
 
 ~~~
@@ -415,7 +415,7 @@ In either case, new extensions need to be defined in an RFC that updates this do
 
 ## Processing Algorithm {#processing}
 
-To process a series of bytes to recover the expressed preferences,
+To process a series of bytes to recover the stated preferences,
 those bytes are parsed into a Dictionary ({{Section 4.2.2 of FIELDS}}),
 then preferences are assigned to each usage category in the vocabulary.
 
@@ -437,7 +437,7 @@ A preference is assigned as follows:
 * If the value is a Token with a value of `n`,
   the associated preference is to disallow that category of use.
 
-* Otherwise, a preference is not expressed for that category of use.
+* Otherwise, no preference is stated for that category of use.
 
 Note that this last alternative includes
 the key being absent from the collection,
@@ -450,13 +450,13 @@ An important note about this process and format is that,
 if the same key appears multiple times,
 only the last value is taken.
 This means that duplicating the same key could result in unexpected outcomes.
-For example, the following expresses no preferences:
+For example, the following states no preferences:
 
 ~~~
 train-ai=y, train-ai="n", train-genai=n, train-genai, all=n, all=()
 ~~~
 
-If the parsing of the Dictionary fails, no preferences are expressed.
+If the parsing of the Dictionary fails, no preferences are stated.
 This includes where keys include uppercase characters,
 as this format is case sensitive
 (more correctly, it operates on bytes, not strings).
@@ -486,15 +486,15 @@ for a subset of the categories of use.
 A mapping might then define that no preference is associated with other categories.
 
 
-# Consulting a Preference Expression {#consulting}
+# Consulting a Preference Statement {#consulting}
 
-After processing a preference expression ({{processing}}),
+After processing a statement of preference ({{processing}}),
 an application can request the status of a specific usage category.
 
-A single preference expression can be evaluated for a usage category
+A single statement of preference can be evaluated for a usage category
 as follows:
 
-1. If the expression contains an explicit preference
+1. If the statement contains an explicit preference
    (either to allow or disallow),
    that is the result.
 
@@ -503,7 +503,7 @@ as follows:
    recursively apply this process to that category
    and use the result of that process.
 
-3. Otherwise, no preference is expressed.
+3. Otherwise, no preference is stated.
 
 This process results in three potential answers:
 allow, disallow, and no preference.
@@ -518,23 +518,23 @@ beyond the scope of this specification.
 
 ## Combining Preferences {#combining}
 
-The application might have multiple preference expressions,
+The application might have multiple statements of preference,
 obtained using different methods.
 
-If multiple preference expressions are active,
-all preference expressions are consulted ({{consulting}}).
+If multiple statements of preference are active,
+all statements are consulted ({{consulting}}).
 This might result in conflicting answers.
 
 Absent some other means of resolving conflicts,
 the following process applies to each usage category:
 
-* If any preference expression indicates that the usage is disallowed,
+* If any statement of preference indicates that the usage is disallowed,
   the result is that the usage is disallowed.
 
 * Otherwise, if any preference preference allows the usage,
   the result is that the usage is allowed.
 
-* Otherwise, no preference is expressed.
+* Otherwise, no preference is stated.
 
 This process ensures that the most restrictive preference applies.
 


### PR DESCRIPTION
This turned out to be a little fiddly, but consistency in use of language can help avoid confusion about meaning and intent. This affects both documents.

Closes #134.