### PR TITLE
Parameters carry through

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -477,7 +477,8 @@ To process a series of bytes to recover the expressed preferences,
 those bytes are parsed into a Dictionary ({{Section 4.2.2 of FIELDS}}),
 then preferences are assigned to each usage category in the vocabulary.
 
-This algorithm produces a keyed collection of values, where each key has at most one value and optional parameters.
+This algorithm produces a keyed collection of values,
+where each key has at most one value and optional parameters.
 
 To obtain preferences,
 iterate through the defined categories in the vocabulary.
@@ -516,7 +517,25 @@ This includes where keys include uppercase characters,
 as this format is case sensitive
 (more correctly, it operates on bytes, not strings).
 
+<<<<<<< Updated upstream
 This process produces an abstract data structure
+=======
+This document does not define a use for parameters.
+Where parameters are used,
+only those parameters associated with the value that is selected
+according to {{Section 4.2.2 of FIELDS}}.
+Parameters can therefore be carried for any preference value,
+including where no preference is expressed.
+
+For example, the following `train-ai` preference has parameters
+even though no preference is expressed:
+
+~~~
+train-ai;has;parameters="?";
+~~~
+
+This process produces an abstract data model
+>>>>>>> Stashed changes
 that assigns a preference to each usage category
 as described in {{model}}.
 


### PR DESCRIPTION
This is, of course, useless in the current state of the design.  But we do allow for the possibility that parameters will be defined.

The only design choice here is whether to respect parameters that are attached to invalid preferences.  The answer is that we do that, because maybe that will turn out to be useful and there is no reason obvious reason not to.

Closes #129.