### PR TITLE
More clarity about vocabulary extensions

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -323,8 +323,10 @@ that include existing categories defined in the vocabulary.
 That is, new categories of use can be defined as a subset of an existing category,
 but not a superset.
 
-Systems that use this vocabulary might define their own extensions,
-see {{mapping}} for how those are managed.
+Systems that use this vocabulary might define their own extensions
+as part of a larger data model.
+{{mapping}} describes how concepts from an alternative format
+might be mapped to this vocabulary.
 
 
 # Applying Statements of Preference {#usage}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -315,10 +315,16 @@ The use of assets for Search is a proper subset of Automated Processing usage.
 
 ## Vocabulary Extensions {#vocab-extension}
 
-Systems referencing the vocabulary MUST NOT introduce additional categories
+Extensions to this vocabulary need to be defined in an RFC
+that updates this document.
+
+Any future extensions to this vocabulary MUST NOT introduce additional categories
 that include existing categories defined in the vocabulary.
 That is, new categories of use can be defined as a subset of an existing category,
 but not a superset.
+
+Systems that use this vocabulary might define their own extensions,
+see {{mapping}} for how those are managed.
 
 
 # Applying Statements of Preference {#usage}
@@ -468,7 +474,8 @@ This document does not define any semantics for any parameters that might be inc
 When processing a parsed Dictionary to obtain preferences,
 any unknown parameters MUST be ignored.
 
-In either case, new extensions need to be defined in an RFC that updates this document.
+In either case,
+new extensions need to be defined in an RFC that updates this document.
 
 
 ## Processing Algorithm {#processing}
@@ -521,7 +528,7 @@ that assigns a preference to each usage category
 as described in {{model}}.
 
 
-## Alternative Formats
+## Alternative Formats {#mapping}
 
 This format is only an exemplary way to represent preferences.
 The model described in {{model}}, can be used without this serialization.


### PR DESCRIPTION
Be clearer about the need for a RFC-based revision to extend the vocabulary, what the constraints on that will still be.

Then make clear that alternative formats could extend their own use of this vocabulary and that we have already dealt with that later in the document.

Closes #122.