### PR TITLE
Add more caveats to the ignoring language

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -198,9 +198,9 @@ how that usage corresponds to the usage categories
 where preferences have been expressed,
 and the applicable legal context.
 
-Usage preferences can be overridden through express agreements
-between relevant parties, by explicit provisions of law, or
-through the exercise of discretion in situations where other
+Usage preferences can be ignored due to express agreements
+between relevant parties, explicit provisions of law, or
+the exercise of discretion in situations where widely recognized
 priorities justify doing so. Priorities that could justify
 ignoring preferences include—but are not limited to—free
 expression, safety, education, scholarship, research,


### PR DESCRIPTION
...because there can't ever be enough, apparently.

The action taken here is ignoring, not overriding.

More importantly, it says that priorities that might be used to justify ignoring preferences need to be "widely recognized". Another use of ambiguous or subjective language, for sure, but one where the test is not completely internal.