### PR TITLE
Add security considerations

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -570,7 +570,12 @@ A mapping might then define that no preference is associated with other categori
 
 # Security Considerations
 
-TODO Security
+Preferences are not a security mechanism.
+{{applicability}} addresses what it means to express a preference.
+
+Processing a concrete instantiation
+of the exemplary format described in {{format}}
+is subject to the security considerations in {{Section 6 of FIELDS}}.
 
 
 # IANA Considerations


### PR DESCRIPTION
This is pretty lightweight, but then this is not highly security-relevant work.  Most of the code/protocol integrity parts are helpfully taken care of elsewhere.  The most important part is to disclaim utility as a security mechanism.