### PR TITLE
Add some text to security

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -191,7 +191,11 @@ Systems referencing the vocabulary must not introduce additional categories that
 
 # Security Considerations
 
-TODO Security
+This document does not authenticate preferences.
+As such, the ability to express a preference is based not on any established authority
+only on access to the asset or its method of delivery.
+Methods of attaching preferences to assets
+therefore need to document the properties that can be assumed of preferences.
 
 
 # IANA Considerations


### PR DESCRIPTION
Right now, this isn't going to be much, because we don't have the format text merged.  When that arrives, we'll need to add some more.

This text is almost applicability-statement material, but I thought it worth putting it here, because it will ensure that attachment methods include security considerations of their own that address the question of authentication.