### PR TITLE
AI Output and Search categories

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -313,7 +313,7 @@ The use of assets for AI Output is a proper subset of Automated Processing usage
 
 ## Search {#search}
 
-The Search category of use is a refinement of the AI Output usage,
+The Search category of use is a refinement of the AI Output category,
 with the addition of the following two conditions:
 
 * A reference to the location that the asset was obtained


### PR DESCRIPTION
This is the output of the informali, impromptu design team that was formed during the last day of meetings.  This attempts to synthesize ideas from numerous sources, including various email threads on the mailing list, drafts shared (in particular
draft-madhavan-aipref-displaybasedpref) and some ideas that were floating around.

This concentrates on system outputs and aims to primarily address concerns about substitutive use.  That is, the potential for AI to generate content that is different from source material, but which might replace it.

We did not include some of the concepts that were in draft-madhavan-aipref-displaybasedpref about limiting output size and so forth, but recognize that those might make good extensions at a later time.  Those will depend on specific formats (text lengths for text, snippet duration for audio or video, etc..) and we concluded that we want to concentrate on the core concept.

This is a less flexible version of the thing that was presented.  Rather than having separate conditions of use attached to a permission grant, one for linking back and another for requiring direct quoting rather than paraphrasing or summarizing.  These too might need further refinement in future.  For example, we talked about how certain formats might be able to identify which content (text, time, whatever) is OK to quote and which is not.

This does not attempt to address the new problem this raises, which is that indicating that you would like these new categories to be allowed in practice also means that you need to say the same for AI training. That's not a problem this is attempting to solve.  We'll need to do that in some other way.