### PR TITLE
Switch training to foundation model production

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -223,7 +223,7 @@ in a particular situation:
   to historical web collections.
 
 * An educational institution might decide to ignore a preference
-  disallowing AI Training ({{train-ai}})
+  disallowing Foundation Model Production ({{train-ai}})
   in order to enable scholars to develop or use tools
   to facilitate scientific or other types of research.
 
@@ -236,6 +236,7 @@ Because enforcement is not provided by this specification,
 the consequences of ignoring preferences could vary
 depending upon how a given legal jurisdiction recognizes preferences.
 
+
 # Vocabulary Definition {#vocab}
 
 This section defines the categories of use in the vocabulary.
@@ -243,29 +244,29 @@ This section defines the categories of use in the vocabulary.
 {{f-categories}} shows the relationship between these categories:
 
 ~~~ aasvg
- .-----------------------------------------------.
-|                                                 |
-|               Automated Processing              |
-|                                                 |
-|                                                 |
-|    .-----------------.      .--------------.    |
-|   |                   |    |                |   |
-|   |                   |    |                |   |
-|   |    AI Training    |    |   AI Output    |   |
-|   |                   |    |                |   |
-|   |                   |    |                |   |
-|   |  .-------------.  |    |  .----------.  |   |
-|   | |               | |    | |            | |   |
-|   | |  Generative   | |    | |   Search   | |   |
-|   | |  AI Training  | |    | |            | |   |
-|   | |               | |    | |            | |   |
-|   |  '-------------'  |    |  '----------'  |   |
-|   |                   |    |                |   |
-|    '-----------------'      '--------------'    |
-|                                                 |
- '-----------------------------------------------'
-~~~
-{: #f-categories title="Relationship Between Categories of Use"}
+ .------------------------------------------------.
+|                                                  |
+|              Automated Processing                |
+|                                                  |
+|                                                  |
+|    .----------------.      .----------------.    |
+|   |                  |    |                  |   |
+|   |                  |    |                  |   |
+|   |    Foundation    |    |    AI Output     |   |
+|   |      Model       |    |                  |   |
+|   |    Production    |    |                  |   |
+|   |                  |    |  .------------.  |   |
+|   |                  |    | |              | |   |
+|    '----------------'     | |    Search    | |   |
+|                           | |              | |   |
+|                           | |              | |   |
+|                           |  '------------'  |   |
+|                           |                  |   |
+|                            '----------------'    |
+|                                                  |
+ '------------------------------------------------'
+~~~~
+{: #f-categories title="Relationsehip Betweeen Categories of Use"}
 
 
 ## Automated Processing Category {#bots}
@@ -276,22 +277,28 @@ which includes but is not limited to patterns, trends and correlations.
 
 The use of assets for automated processing encompasses all the subsequent categories.
 
-## AI Training Category {#train-ai}
 
-The act of training machine learning models or artificial intelligence (AI).
+## Foundation Model Production Category {#train-ai}
 
-The use of assets for AI Training is a proper subset of Automated Processing usage.
+The act of using an asset to train or fine-tune a foundation model.
 
-## Generative AI Training Category {#train-genai}
+Foundation models are large models that are produced using deep learning
+or other machine learning techniques.
+Foundation models are trained on very large numbers of assets
+so that they can be applied to a wide range of use cases.
+Foundation models typically possess generative capabilities
+in one or more media.
 
-The act of training general purpose AI models that have the capacity to generate text, images or other forms of synthetic content, or the act of training more specialized AI models that have the purpose of generating text, images or other forms of synthetic content.
+Fine-tuning can specialize a general-purpose foundation model
+for a narrower set of use cases.
 
-The use of assets for Generative AI Training is a proper subset of AI Training usage.
+The use of assets for Foundation Model Production
+is a proper subset of Automated Processing usage.
 
 
 ## AI Output {#ai-output}
 
-Using an asset in an AI-based system
+The act of using an asset in an AI-based system
 to generate outputs
 that are presented to clients of that system.
 
@@ -431,13 +438,13 @@ The dictionary keys correspond to usage categories
 and the dictionary values correspond to explicit preferences,
 which can be either `y` or `n`; see {{y-or-n}}.
 
-For example, the following states a preference to allow AI training ({{train-ai}}),
-disallow generative AI training ({{train-genai}}), and
+For example, the following states a preference to allow automated processing ({{bots}}),
+disallow foundation model production ({{train-ai}}), and
 and states no preference for other categories
 other than subsets of these categories:
 
 ~~~
-train-ai=y, train-genai=n
+bots=y, train-ai=n
 ~~~
 
 
@@ -446,13 +453,12 @@ train-ai=y, train-genai=n
 Each usage category in the vocabulary ({{vocab}}) is mapped to a short textual label.
 {{t-category-labels}} tabulates this mapping.
 
-| Category               | Label       | Reference       |
-|:-----------------------|:------------|:----------------|
-| Automated Processing   | bots        | {{bots}}        |
-| AI Training            | train-ai    | {{train-ai}}    |
-| Generative AI Training | train-genai | {{train-genai}} |
-| AI Output              | ai-output   | {{ai-output}}   |
-| Search                 | search      | {{search}}      |
+| Category                    | Label       | Reference       |
+|:----------------------------|:------------|:----------------|
+| Automated Processing        | bots        | {{bots}}        |
+| Foundation Model Production | train-ai    | {{train-ai}}    |
+| AI Output                   | ai-output   | {{ai-output}}   |
+| Search                      | search      | {{search}}      |
 {: #t-category-labels title="Mappings for Categories"}
 
 These tokens are case sensitive.
@@ -547,7 +553,7 @@ This means that duplicating a key could result in unexpected outcomes.
 For example, the following expresses no preferences:
 
 ~~~
-train-ai=y, train-ai="n", train-genai=n, train-genai, bots=n, bots=()
+train-ai=y, train-ai="n", search=n, search, bots=n, bots=()
 ~~~
 
 If the parsing of the Dictionary fails, no preferences are stated.


### PR DESCRIPTION
This takes the two pre-existing model training categories and changes it into a foundation model training category.

There are a few challenges in our current definitions, particularly around the base "AI Training" category.  As some have noted, the definition of AI is a bit fuzzy.  This avoids that by relying on what is now a widely-recognized definition.

That definition is not uniform, so I'm following the sage advice of a colleague.  They suggested that making a definition for the specific use case is best, because it allows for the definition to fit better to the domain in which it is applied.

Some notes about aspects of "foundation model"
where this varies from accepted definitions:

* Some definitions make a point of including a measure of model size. US legislation says "tens of billions of parameters"; others suggest a firmer one billion parameter threshold.  Here, most definitions don't bother, except to note that the model is "large" and trained on lots of data.  Not being concrete seems like it will be safest.
* Many definitions refer to self-supervised learning as being typical in the creation of foundation models.  Because this is phrased with a "generally" or "typically" -- and because techniques can and do change -- it seemed like this wasn't a useful addition to the definition.
* This includes a note that the model has some generative capability. In direct contradiction to my previous note about "typically", that's a word I've used here.  My sense is that it is important to recognize this capability, particular as we are replacing the "generative AI training" category here.

The definition here includes fine-tuning.  This is not strictly a foundation model thing, but my view is that a fine-tuned model is highly likely to also be a foundation model.  Not including that in the definition would not be consistent with the spirit of the preferences. I acknowledge that this creates new questions and challenges -- what about techniques like LoRA? does the name really match the scope? -- but my view is that this is a better fit for expectations.

This does not remove any of the more general definitions that were created to support the previous definitions (AI, training, ML, etc...). My current view is that these are less critical now that the definition is essentially self-contained.  We might consider removing them later. They are certainly far less load-bearing now, so that is an easier decision to make.  (I'm coming to the view that each category should have a self-contained definition without relying on external definitions, so that puts those definitions on notice.)