### PR TITLE
No preference -> unknown preference

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -538,7 +538,7 @@ it only needs to be clear and unambiguous.
 For example, an alternative format
 might only provide the ability to convey preferences
 for a subset of the categories of use.
-A mapping might then define that a preference of unknown
+A mapping might then define that an unknown preference
 is associated with other categories.
 
 


### PR DESCRIPTION
We've used "no preference" or "no expression of preference" in a few places.  It could be clearer.

Closes #174.