### PR TITLE
Conformance -> understanding

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -180,7 +180,7 @@ What a recipient then does with that information depends on many factors;
 see {{applicability}}.
 
 There are also some caveats that need to be considered
-as it relates to understanding what preferences are
+as it relates to understanding what the preferences for a given asset are
 (as opposed to what actions might then follow).
 
 A recipient can only understand preferences expressed
@@ -192,15 +192,15 @@ using a method the recipient does not understand or recognize,
 the recipient will remain ignorant of that preference.
 
 Depending on the way in which preferences are expressed,
-a recipient might be unable to tell who has expressed a preference.
+a recipient might be unable to tell the source of the preference.
 Unless the source is explicitly identified,
 no assumptions can be made about where a preference originates.
 For example, preferences in robots.txt (see {{Section 3 of ATTACH}})
-only implies that the operator of a server
+only implies that a server
 is the source of those preferences.
 
 A method of associating preferences with assets
-could explicitly define who is responsible for preferences,
+could explicitly define the source of the preferences,
 which might involve authentication.
 Otherwise, no assumptions can be made about the origin of preferences.
 The apparent source of preferences

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -183,7 +183,8 @@ There are also some caveats that need to be considered
 as it relates to understanding what preferences are
 (as opposed to what actions might then follow).
 
-A recipient chooses the methods of expressing preferences it recognizes.
+A recipient can only understand preferences expressed
+through mechanisms it has implemented.
 Those methods might be limited to those in {{ATTACH}}
 or it could also include other methods (see {{Section 1.3 of ATTACH}}).
 If a preference is associated with an asset

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -168,17 +168,47 @@ The process for managing multiple statements of preference is defined in {{combi
 An exemplary syntax for statements of preference is defined in {{format}}.
 
 
-## Conformance
+## Understanding Preferences {#understanding}
 
 This document and {{ATTACH}}
 describe how statements of preference are associated with assets.
-An implementation is conformant to these specifications
-if it correctly follows all normative requirements that apply to it.
 
-The process of obtaining a statement of preference has very limited scope
-for variation between implementations.
+The goal of these specifications is to ensure
+that the recipient of an asset knows
+what preferences have been associated with the asset.
+What a recipient then does with that information depends on many factors;
+see {{applicability}}.
 
-## Applicability and Effect {#applicability}
+There are also some caveats that need to be considered
+as it relates to understanding what preferences are
+(as opposed to what actions might then follow).
+
+A recipient chooses the methods of expressing preferences it recognizes.
+Those methods might be limited to those in {{ATTACH}}
+or it could also include other methods (see {{Section 1.3 of ATTACH}}).
+If a preference is associated with an asset
+using a method the recipient does not understand or recognize,
+the recipient will remain ignorant of that preference.
+
+Depending on the way in which preferences are expressed,
+a recipient might be unable to tell who has expressed a preference.
+Unless the source is explicitly identified,
+no assumptions can be made about where a preference originates.
+For example, preferences in robots.txt (see {{Section 3 of ATTACH}})
+only implies that the operator of a server
+is the source of those preferences.
+
+A method of associating preferences with assets
+could explicitly define who is responsible for preferences,
+which might involve authentication.
+Otherwise, no assumptions can be made about the origin of preferences.
+The apparent source of preferences
+could be representing their own preferences,
+the preferences of others,
+or the synthesis of multiple preferences from different sources.
+
+
+## Applying Preferences {#applicability}
 
 This specification provides a set of definitions for different
 categories of use, plus a system for associating simple


### PR DESCRIPTION
This change attempts to reframe Sections 3.1 and 3.2 in terms of the two things they are intended to address, each separately.

* Section 3.1 is about what it means to understand what a preference is.

* Section 3.2 is about what it might mean to act on that understanding.

It seems like this distinction was unclear in the past and this is primarily an attempt to address that confusion.

At the risk of adding to the confusion though, I felt like it was responsible to talk about the limitations of what we can achieve in that first item.  After all, the system we describe has limitations.  Those are twofold:

1.  People who receive/obtain assets will not understand every possible way of expressing preferences.  So only those preferences they know about and choose to implement will be understood by them.

2.  We are not always offering a way to convey *who* expressed a preference.  Some mechanisms might depend on that (the registry ideas need to, for instance), but the ones we are defining today cannot.

Neither should be especially surprising to anyone, but writing something that is precise turned out to be tricky.  I'm not happy with where it is, but am turning to wider review for feedback.