### PR TITLE
Switch from "ignore" to focus on a choice not to honor preferences

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -194,9 +194,10 @@ legal, contractual, or otherwise—might enforce stated preferences
 and thereby determine the consequences of following or not following
 a stated preference.
 
-An entity that receives usage preferences MAY choose to respect
-those preferences it has discovered, according to
-an understanding of how the asset is used,
+An entity that receives usage preferences has a choice
+about whether to respect the preferences it has discovered.
+It makes this choice according to its understanding
+of how the asset is used,
 how that usage corresponds to the usage categories
 where preferences have been stated,
 and the applicable legal context.

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -202,16 +202,20 @@ how that usage corresponds to the usage categories
 where preferences have been stated,
 and the applicable legal context.
 
-Usage preferences can be ignored due to express agreements
-between relevant parties, explicit provisions of law, or
-the exercise of discretion in situations where widely recognized
-priorities justify doing so. Priorities that could justify
-ignoring preferences include—but are not limited to—free
-expression, safety, education, scholarship, research,
+An entity that chooses not to honor preferences
+might do so due to
+express agreements between relevant parties,
+explicit provisions of law, or
+the exercise of discretion in situations
+where widely recognized priorities justify doing so.
+Priorities that could justify ignoring preferences include --
+but are not limited to --
+safety, education, scholarship, research,
 preservation, interoperability, and accessibility.
 
 The following lists examples of cases
-where other priorities could lead someone to ignore expressed preferences
+where other priorities could lead someone
+to choose not to honor expressed preferences
 in a particular situation:
 
 * People with accessibility needs,


### PR DESCRIPTION
This is a lighter-weight approach to addressing the comments raised in #160.  It retains the longer list of reasons that people might choose not to honor preferences.

Closes #160.