### PR TITLE
Refine section 4.1 based on Toronto discussion

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -237,7 +237,7 @@ This section defines the categories of use in the vocabulary.
 
 ## AI Model Training {#train-ai}
 
-Using an asset to modify the common parameters of an AI model
+Using an asset to modify the learned parameters of an AI model
 that is used
 to generate synthetic content in one or more modalities.
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -237,11 +237,9 @@ This section defines the categories of use in the vocabulary.
 
 ## AI Model Training {#train-ai}
 
-The act of using an asset
-in the production or refinement of an AI model
-that can generate content in one or more modalities
-(text, image, audio, etc...).
-
+Using an asset to modify the common parameters of an AI model
+that is used, or made available for use,
+to generate synthetic content in one or more modalities.
 
 ## Search {#search}
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -238,7 +238,7 @@ This section defines the categories of use in the vocabulary.
 ## AI Model Training {#train-ai}
 
 Using an asset to modify the common parameters of an AI model
-that is used, or made available for use,
+that is used
 to generate synthetic content in one or more modalities.
 
 ## Search {#search}


### PR DESCRIPTION
Here are the proposed tweaks to the definition of model training that I mentioned on the interim call.  (This was originally homework from Toronto; sorry that it's taken so long to post.)  I think that this gets us to a description of what it means to train a general-purpose foundation model without relying on any of the words that have raised objections in past drafts.

The most substantive change I'm proposing in this PR is that we move from talking about a model that "can generate" to one that "is used, or made available for use, to generate."  One of the things that I heard most clearly in Toronto from people thinking about declaring preferences was concern about the subjectivity of definitions based on purpose and intent, and about the possibility that either might change over time.

This makes the category slightly more narrow, but also more objective—something either was used or it wasn't; much less is subject to interpretation.  The same property should let implementers apply the category consistently, too.

This approach also focuses on the activity rather than the technology, which I hope addresses the concerns that were raised in Toronto about unintended consequences.

I've expanded "used" to "used, or made available for use" in an attempt to address the concerns that were raised about open-weight models and organizational boundaries.

I've replaced the "produce or refine" language in the current draft with "modify", which I think encompasses both; producing a model is the process of iteratively refining its weights.

I've also kept "asset" from the current draft.  I know that some folks had concerns about that term in Toronto; I don't feel strongly about it, so long as we have a word for "piece of data".