### PR TITLE
Simplify Section 3.2

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -225,8 +225,8 @@ NOTE: This section does not yet have consensus; see "Note to Readers" above.
 
 This section defines the categories of use in the vocabulary.
 
-They describe concrete, observable outcomes that depend on the use of assets,
-they seek to avoid describing internal details of implementations
+These categories describe concrete, observable outcomes that depend on the use of assets.
+The definitions seek to avoid describing internal details of implementations
 or their architecture.
 
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -197,15 +197,6 @@ or the synthesis of multiple preferences from different sources.
 
 ## Applying Preferences {#applicability}
 
-This specification provides a set of definitions for different
-categories of use, plus a system for associating simple
-preferences to each (allow, disallow, or unknown; see {{model}}).
-
-The categories of use in the vocabulary (see {{vocab}})
-describe concrete, observable outcomes that depend on the use of assets,
-they seek to avoid describing internal details of implementations
-or their architecture.
-
 This specification only seeks to ensure that preferences can be understood,
 not provide a means of ensuring that preferences are respected.
 There may be considerations that take precedence over any stated preferences,
@@ -233,6 +224,10 @@ and the applicable legal context.
 NOTE: This section does not yet have consensus; see "Note to Readers" above.
 
 This section defines the categories of use in the vocabulary.
+
+They describe concrete, observable outcomes that depend on the use of assets,
+they seek to avoid describing internal details of implementations
+or their architecture.
 
 
 ## AI Model Training {#train-ai}


### PR DESCRIPTION
This removes two paragraphs from Section 3.2, following discussion in the subgroup that's formed to focus on this part of the draft.

- The first reiterates what's stated elsewhere in the draft
- The second describes the categories, so belongs in Section 4

