### PR TITLE
Update §3.2 Applying Preferences and §4 Vocabulary Definition

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -225,8 +225,8 @@ NOTE: This section does not yet have consensus; see "Note to Readers" above.
 
 This section defines the categories of use in the vocabulary.
 
-They describe concrete, observable outcomes that depend on the use of assets,
-they seek to avoid describing internal details of implementations
+These categories describe concrete, observable outcomes that depend on the use of assets.
+The definitions seek to avoid describing internal details of implementations
 or their architecture.
 
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -197,15 +197,6 @@ or the synthesis of multiple preferences from different sources.
 
 ## Applying Preferences {#applicability}
 
-This specification provides a set of definitions for different
-categories of use, plus a system for associating simple
-preferences to each (allow, disallow, or unknown; see {{model}}).
-
-The categories of use in the vocabulary (see {{vocab}})
-describe concrete, observable outcomes that depend on the use of assets,
-they seek to avoid describing internal details of implementations
-or their architecture.
-
 This specification only seeks to ensure that preferences can be understood,
 not provide a means of ensuring that preferences are respected.
 There may be considerations that take precedence over any stated preferences,
@@ -233,6 +224,10 @@ and the applicable legal context.
 NOTE: This section does not yet have consensus; see "Note to Readers" above.
 
 This section defines the categories of use in the vocabulary.
+
+They describe concrete, observable outcomes that depend on the use of assets,
+they seek to avoid describing internal details of implementations
+or their architecture.
 
 
 ## AI Model Training {#train-ai}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -198,7 +198,7 @@ or the synthesis of multiple preferences from different sources.
 ## Applying Preferences {#applicability}
 
 This specification enables the expression of a defined set of preferences that
-can be communicated and interoperably understood.  Readers of this
+can be communicated and interoperably understood. Readers of this
 specification should understand that it does not:
 
 - provide for enforcement;

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -209,8 +209,9 @@ specification should understand that it does not:
   expressed preferences.
 
 An entity that receives usage preferences has a choice whether to follow those
-preferences. Multiple factors could influence that decision, but the decision
-itself is outside the scope of this document.
+preferences. This specification does not determine how that choice is made.
+Whether and under which circumstances a preference is followed is outside the
+scope of this specification.
 
 
 # Vocabulary Definition {#vocab}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -197,26 +197,20 @@ or the synthesis of multiple preferences from different sources.
 
 ## Applying Preferences {#applicability}
 
-This specification only seeks to ensure that preferences can be understood,
-not provide a means of ensuring that preferences are respected.
-There may be considerations that take precedence over any stated preferences,
-especially when taking the public interest into account.
+This specification enables the expression of a defined set of preferences that
+can be communicated and interoperably understood.  Readers of this
+specification should understand that it does not:
 
-Enforcement is not provided by this specification.
-Preferences do not themselves create rights, obligations, or prohibitions.
-Other mechanisms --
-technical, legal, contractual, or otherwise --
-might enforce adherence or non-adherance to these preferences
-and thereby determine the consequences of not respecting
-a stated preference.
+- provide for enforcement;
+- address if, how, or when preferences should be followed or ignored;
+- address external mechanisms -- technical, legal, contractual, or otherwise --
+  that might determine adherence or non-adherence to these preferences;
+- consider situations or purposes that might justify following or ignoring
+  expressed preferences.
 
-An entity that receives usage preferences has a choice
-about whether to respect the preferences it has discovered.
-It makes this choice according to its understanding
-of how the asset is used,
-how that usage corresponds to the usage categories
-where preferences have been stated,
-and the applicable legal context.
+Because of this, stakeholders need to evaluate when and how to respect
+preferences in the context of other legal, institutional, or ethical
+commitments.
 
 
 # Vocabulary Definition {#vocab}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -201,16 +201,16 @@ This specification enables the expression of a defined set of preferences that
 can be communicated and interoperably understood. Readers of this
 specification should understand that it does not:
 
-- provide for enforcement of these preferences;
+- ensure that preferences are followed;
 - address if, how, or when preferences should be followed or not-followed;
 - address technical, legal, contractual, or other mechanisms that might create
   a stronger requirement to follow or not follow preferences;
 - consider situations or purposes that might justify following or not-following
   expressed preferences.
 
-Because of this, stakeholders need to decide when and how to follow or
-not-follow preferences in the context of legal, institutional, ethical, or
-other interests and commitments.
+An entity that receives usage preferences has a choice whether to follow those
+preferences. Multiple factors could influence that decision, but the decision
+itself is outside the scope of this document.
 
 
 # Vocabulary Definition {#vocab}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -201,16 +201,16 @@ This specification enables the expression of a defined set of preferences that
 can be communicated and interoperably understood. Readers of this
 specification should understand that it does not:
 
-- provide for enforcement;
-- address if, how, or when preferences should be followed or ignored;
+- provide for enforcement of these preferences;
+- address if, how, or when preferences should be followed or not-followed;
 - address technical, legal, contractual, or other mechanisms that might create
   a stronger requirement to follow or not follow preferences;
-- consider situations or purposes that might justify following or ignoring
+- consider situations or purposes that might justify following or not-following
   expressed preferences.
 
-Because of this, stakeholders need to decide when and how to follow or ignore
-preferences in the context of other legal, institutional, or ethical
-commitments.
+Because of this, stakeholders need to decide when and how to follow or
+not-follow preferences in the context of other legal, institutional, or
+ethical commitments.
 
 
 # Vocabulary Definition {#vocab}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -203,8 +203,8 @@ specification should understand that it does not:
 
 - provide for enforcement;
 - address if, how, or when preferences should be followed or ignored;
-- address external mechanisms -- technical, legal, contractual, or otherwise --
-  that might determine adherence or non-adherence to these preferences;
+- address technical, legal, contractual, or other mechanisms that might create
+  a stronger requirement to follow or not follow preferences;
 - consider situations or purposes that might justify following or ignoring
   expressed preferences.
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -209,8 +209,8 @@ specification should understand that it does not:
   expressed preferences.
 
 Because of this, stakeholders need to decide when and how to follow or
-not-follow preferences in the context of other legal, institutional, or
-ethical commitments.
+not-follow preferences in the context of legal, institutional, ethical, or
+other interests and commitments.
 
 
 # Vocabulary Definition {#vocab}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -208,7 +208,7 @@ specification should understand that it does not:
 - consider situations or purposes that might justify following or ignoring
   expressed preferences.
 
-Because of this, stakeholders need to evaluate when and how to respect
+Because of this, stakeholders need to decide when and how to follow or ignore
 preferences in the context of other legal, institutional, or ethical
 commitments.
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -225,9 +225,9 @@ NOTE: This section does not yet have consensus; see "Note to Readers" above.
 
 This section defines the categories of use in the vocabulary.
 
-These categories describe concrete, observable outcomes that depend on the use of assets.
-The definitions seek to avoid describing internal details of implementations
-or their architecture.
+These categories describe concrete, observable outcomes that depend on the use
+of assets.  The definitions seek to avoid describing internal details of
+implementations or their architecture.
 
 
 ## AI Model Training {#train-ai}


### PR DESCRIPTION
**Update Sections 3.2 Applying Preferences and Section 4 Vocabulary Definition**
- Replace Sections 3.2 Applying Preferences with proposed text from subgroup, updated to incorporate Editors' suggestions.
  - Goals of the update include (non-exhaustive):
    - Simplify and ease reader comprehension
    - Provide waypoints for well-intended conscientious public actors
    - Call attention to the limitations of the Vocabulary
  - The above goals are in tension. Hopefully the proposed text strikes a good balance that minimizes misunderstanding and unintentional harms.
- Add clarifying text to Section 4 Vocabulary Definition (this PR builds on #212)
- Uses non-normative language per:
  - #162