### PR TITLE
Add "AI System Inference" and "AI User Input" categories

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -289,6 +289,22 @@ are used exclusively
 in ways that meet the above conditions.
 
 
+## AI System Inference {#ai-system-inference}
+
+Using an asset for inference by an AI model that is used to generate synthetic content in one or more modalities. 
+Inference means all use beyond the modification of an AI model’s learned parameters. 
+This category does not include the use of assets that a human end user has specifically identified 
+(by providing either the asset itself or a location from which it can be retrieved).
+
+
+## AI User Input {#ai-user-input}
+
+Using an asset that a human end user has specifically identified 
+(by providing either the asset itself or a location from which it can be retrieved)
+for inference by an AI model that is used to generate synthetic content in one or more modalities. 
+Inference means all use beyond the modification of an AI model’s learned parameters.
+
+
 ## Vocabulary Extensions {#vocab-extension}
 
 Extensions to this vocabulary need to be defined in an RFC

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -106,6 +106,9 @@ Asset:
 Declaring party:
 : The entity that expresses a preference with regards to an Asset.
 
+Inference:
+: All use of an AI system, except use that modifies the learned parameters of an AI model.
+
 
 # Statements of Preference {#model}
 
@@ -289,20 +292,15 @@ are used exclusively
 in ways that meet the above conditions.
 
 
-## AI System Inference {#ai-system-inference}
+## Inference Directed by User {#ai-inference-user}
 
-Using an asset for inference by an AI model that is used to generate synthetic content in one or more modalities. 
-Inference means all use beyond the modification of an AI model’s learned parameters. 
-This category does not include the use of assets that a human end user has specifically identified 
-(by providing either the asset itself or a location from which it can be retrieved).
+Using an asset during inference where the asset has been explicitly selected by a human user. 
+This includes assets provided directly by the user or assets whose location has been explicitly specified by the user.
 
 
-## AI User Input {#ai-user-input}
+## Inference Directed by System {#ai-inference-system}
 
-Using an asset that a human end user has specifically identified 
-(by providing either the asset itself or a location from which it can be retrieved)
-for inference by an AI model that is used to generate synthetic content in one or more modalities. 
-Inference means all use beyond the modification of an AI model’s learned parameters.
+Using an asset during inference where the asset is selected by the system itself or any other mechanism that is not a human user.
 
 
 ## Vocabulary Extensions {#vocab-extension}


### PR DESCRIPTION
This adds two proposed inference/use vocab categories that are intended to work in tandem: 
-AI System Inference 
-AI User Input

These definitions both rely on the AI training definition of PR 211 as a logical starting point. They define inference as all use of assets by AI models beyond the modification of learned parameters. 

Together, these proposed categories would enable the expression of preferences covering the full field of post-training usage. They also give declaring parties the option to express different preferences when assets are used by autonomous systems vs when assets are identified by a human end user.