### PR TITLE
Address distinction between access and use

### DIFF
--- a/draft-ietf-aipref-attach.md
+++ b/draft-ietf-aipref-attach.md
@@ -100,24 +100,6 @@ these allow for the automated gathering of preferences
 in the same way that content is obtained.
 
 
-## Acquisition and Following Preferences
-
-The acquisition of an asset --
-or the receiving of a representation --
-is distinct from how that asset is subsequently used.
-
-Consequently, this document takes the view
-that usage preferences do not apply
-to the acquisition of assets.
-They only apply to how those assets are used;
-see {{Section 3.2 of VOCAB}} for a discussion
-on what it means to follow or not follow a preference.
-
-Mechanisms for limiting access to assets,
-such as access control or the `Disallow` rules in "robots.txt",
-are out of scope for this work.
-
-
 ## Statements of Preference
 
 The format of a statement of preference
@@ -157,6 +139,45 @@ User-Agent: *
 Allow: /
 Content-Usage: train-ai=n
 ~~~
+
+
+## Acquisition and Following of Preferences
+
+The acquisition of an asset --
+or the receiving of a representation --
+is distinct from how that asset is subsequently used.
+
+Consequently, this document takes the view
+that usage preferences do not apply
+to the acquisition of assets.
+They only apply to how those assets are used;
+see {{Section 3.2 of VOCAB}} for a discussion
+on what it means to follow or not follow a preference.
+
+Mechanisms for limiting access to assets,
+such as access control or the `Disallow` rules in "robots.txt",
+are out of scope for this work.
+
+
+## Retention and Distribution of Preferences
+
+The mechanisms in this document provide usage preferences
+external to the data that comprises the asset.
+
+A system might need to apply usage preferences
+in a decision some time after obtaining the asset.
+Such a system therefore needs to retain
+any applicable preferences alongside assets
+until any decision are made.
+
+Where acquisition and use occur in separate subsystems,
+the subsystem responsible for acquisition
+needs to provide some means
+of associating the usage preferences it receives
+with the assets it makes available for use.
+A subsystem that uses an asset
+cannot assume that no preferences have been expressed
+without such a mechanism.
 
 
 ## Other Mechanisms

--- a/draft-ietf-aipref-attach.md
+++ b/draft-ietf-aipref-attach.md
@@ -100,6 +100,24 @@ these allow for the automated gathering of preferences
 in the same way that content is obtained.
 
 
+## Acquisition and Following Preferences
+
+The acquisition of an asset --
+or the receiving of a representation --
+is distinct from how that asset is subsequently used.
+
+Consequently, this document takes the view
+that usage preferences do not apply
+to the acquisition of assets.
+They only apply to how those assets are used;
+see {{Section 3.2 of VOCAB}} for a discussion
+on what it means to follow or not follow a preference.
+
+Mechanisms for limiting access to assets,
+such as access control or the `Disallow` rules in "robots.txt",
+are out of scope for this work.
+
+
 ## Statements of Preference
 
 The format of a statement of preference

--- a/draft-ietf-aipref-attach.md
+++ b/draft-ietf-aipref-attach.md
@@ -147,9 +147,8 @@ The acquisition of an asset --
 or the receiving of a representation --
 is distinct from how that asset is subsequently used.
 
-Consequently, this document takes the view
-that usage preferences do not apply
-to the acquisition of assets.
+Usage preferences do not apply
+to how assets are acquired.
 They only apply to how those assets are used;
 see {{Section 3.2 of VOCAB}} for a discussion
 on what it means to follow or not follow a preference.


### PR DESCRIPTION
There's a lengthy discussion of this in #167 and #193, but the change here is short enough, I think.

This addresses questions of the difference between getting something and then using it.  It also addresses the expectations about preferences with respect to uses of assets downstream of acquisition.  This is particularly relevant to the attachment mechanisms we have here (unlike embedded metadata or registries) because the preferences are external to the asset itself.

Closes #167.
Closes #193.