### PR TITLE
Remove text on presentation restrictions in search

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -249,9 +249,6 @@ are included for the purposes of accessibility.
 Translation, transcription, or text-to-speech
 are examples of non-substantive changes
 that could help users understand what is being presented.
-Where existing controls restrict presentation of these items,
-such as limitations on snippet size,
-those apply before any changes.
 
 A preference to allow this category of use
 includes allowing any processing internal to the application


### PR DESCRIPTION
Not remembering exactly why this text was added makes this hard. My theory is that the intent was to make it clear that restrictions on how assets are presented in search are made relative to the way in which the asset is presented: it's language and the format (text vs. voice vs. video, etc...) in particular.  In that way, it would make no sense to apply a transformation (text-to-speech, say) for accessibility reasons and only then try to apply a presentation restriction (100 character limit as an example of something that makes no sense).

However, that's not an us problem.  Anyone defining such a restriction - or anyone choosing to apply a transformation - can make a better decision about this than us.  Let us not burden our definitions, which are already fraught enough, with this additional wrinkle.

See discussion at https://mailarchive.ietf.org/arch/msg/ai-control/JKSRzKZ1_Dfkqpvh70-7irJm_ZA