### PR TITLE
Attempt to directly address agreements

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -194,6 +194,7 @@ specification should understand that it does not:
 
 - ensure that preferences are followed;
 - address if, how, or when preferences should be followed or not-followed;
+- override agreements between parties;
 - address technical, legal, contractual, or other mechanisms that might create
   a stronger requirement to follow or not follow preferences;
 - consider situations or purposes that might justify following or not-following


### PR DESCRIPTION
This is a minimal implementation of what @maxgendler proposes in #192.  It adds it to Section 3.2, which is risky, but that has the advantage of making the list there 5 items rather than 4 (and 4 is a number best avoided as a number of list items).


Closes #192.