### PR TITLE
Replace "asset" term with "resource"

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -40,6 +40,7 @@ normative:
 
 informative:
   UTF8: RFC3629
+  URI: RFC3986
   ATTACH:
     title: "A Vocabulary For Expressing AI Usage Preferences"
     date: draft-ietf-aipref-attach-date
@@ -59,9 +60,9 @@ informative:
 --- abstract
 
 This document defines a vocabulary for expressing preferences
-regarding how digital assets are used by automated processing systems.
+regarding how digital resources are used by automated processing systems.
 This vocabulary allows for the declaration
-of restrictions or permissions for use of digital assets by such systems.
+of restrictions or permissions for use of digital resources by such systems.
 
 --- note_Note_to_Readers
 
@@ -72,7 +73,7 @@ As detailed below, this is a working document. Its contents DO NOT REFLECT CONSE
 # Introduction
 
 This document defines a vocabulary of preferences
-regarding how automated systems process digital assets --
+regarding how automated systems process digital resources --
 in particular, the training and use of AI models.
 This vocabulary can be used to describe
 the types of uses that a declaring party may wish to explicitly restrict or allow.
@@ -89,7 +90,7 @@ including the applicability of exceptions and limitations to copyright.
 and {{format}} describes a way to serialize preferences into a string.
 {{usage}} describes a process for determining the preference for a category of use.
 
-{{ATTACH}} defines mechanisms to associate preferences with assets.
+{{ATTACH}} defines mechanisms to associate preferences with resources.
 Other means of association might be defined separately in the future.
 
 
@@ -100,11 +101,14 @@ Other means of association might be defined separately in the future.
 This document uses the following terms:
 
 {: newline="true" spacing="compact"}
-Asset:
+Resource:
 : A digital file or stream of data, usually with associated metadata.
+  This is a narrower usage than that of {{URI}},
+  which uses "resource" as a general term
+  for anything that might be identified by a URI.
 
 Declaring party:
-: The entity that expresses a preference with regards to an Asset.
+: The entity that expresses a preference with regards to a Resource.
 
 
 # Statements of Preference {#model}
@@ -112,10 +116,10 @@ Declaring party:
 NOTE: This section does not yet have consensus; see "Note to Readers" above.
 
 The vocabulary is a set of categories,
-each of which is defined to cover a class of usage for assets.
+each of which is defined to cover a class of usage for resources.
 {{vocab}} defines the core set of usage categories in detail.
 
-A statement of preference -- or usage preference -- is made about an asset.
+A statement of preference -- or usage preference -- is made about a resource.
 A statement of preference follows a simple data model where a preference
 is assigned to each of the categories of use in the vocabulary.
 A preference is either to allow or disallow
@@ -134,7 +138,7 @@ all usage categories are assigned a preference value of "unknown".
 The process for consulting a statement of preference is defined in {{usage}}.
 
 Different declaring parties might each make their own statement of preference
-regarding a particular asset.
+regarding a particular resource.
 The process for managing multiple statements of preference is defined in {{combine}}.
 
 An exemplary syntax for statements of preference is defined in {{format}}.
@@ -143,16 +147,16 @@ An exemplary syntax for statements of preference is defined in {{format}}.
 ## Understanding Preferences {#understanding}
 
 This document and {{ATTACH}}
-describe how statements of preference are associated with assets.
+describe how statements of preference are associated with resources.
 
 The goal of these specifications is to ensure
-that the recipient of an asset knows
-what preferences have been associated with the asset.
+that the recipient of a resource knows
+what preferences have been associated with the resource.
 What a recipient then does with that information depends on many factors;
 see {{applicability}}.
 
 There are also some caveats that need to be considered
-as it relates to understanding what the preferences for a given asset are
+as it relates to understanding what the preferences for a given resource are
 (as opposed to what actions might then follow).
 
 A recipient can only apply preferences it understands.
@@ -164,7 +168,7 @@ A recipient will only process preferences expressed
 through methods it has implemented.
 Those methods might be limited to those in {{ATTACH}}
 or it could also include other methods (see {{Section 1.3 of ATTACH}}).
-If a preference is associated with an asset
+If a preference is associated with a resource
 using a method the recipient does not understand or recognize,
 the recipient will remain ignorant of that preference.
 
@@ -176,7 +180,7 @@ For example, preferences in robots.txt (see {{Section 3 of ATTACH}})
 only implies that a server
 is the source of those preferences.
 
-A method of associating preferences with assets
+A method of associating preferences with resources
 could explicitly define the source of the preferences,
 which might involve authentication.
 Otherwise, no assumptions can be made about the origin of preferences.
@@ -212,39 +216,39 @@ NOTE: This section does not yet have consensus; see "Note to Readers" above.
 This section defines the categories of use in the vocabulary.
 
 These categories describe concrete, observable outcomes that depend on the use
-of assets.  The definitions seek to avoid describing internal details of
+of resources.  The definitions seek to avoid describing internal details of
 implementations or their architecture.
 
 
 ## AI Model Training {#train-ai}
 
-Using an asset to modify the learned parameters of an AI model
+Using a resource to modify the learned parameters of an AI model
 that is used
 to generate synthetic content in one or more modalities.
 
 ## Search {#search}
 
-Use of an asset in an application
+Use of a resource in an application
 where the primary purpose of the application
-is to select assets
-and direct users to the location of those assets.
+is to select resources
+and direct users to the location of those resources.
 
 This category of use only applies under the following conditions:
 
-* Where the presentation of an asset in search output --
+* Where the presentation of a resource in search output --
   if selected for presentation --
   includes a direct reference or link
-  to the original location from which the asset was retrieved.
+  to the original location from which the resource was retrieved.
 
-* When excerpts from the asset are displayed
+* When excerpts from the resource are displayed
   they serve to assist users
   in evaluating the relevance of the result.
 
-This category does not include the use of assets
+This category does not include the use of resources
 to generate summaries.
 
 Non-substantive changes to the presentation
-of titles or excerpts from assets
+of titles or excerpts from resources
 are included for the purposes of accessibility.
 Translation, transcription, or text-to-speech
 are examples of non-substantive changes
@@ -255,12 +259,12 @@ those apply before any changes.
 
 A preference to allow this category of use
 includes allowing any processing internal to the application
-that is performed on assets.
+that is performed on resources.
 Allowing this use is conditional on the outputs of any processing
 being exclusively used by the search application
 according to the other restrictions in this section.
 That includes the training of AI models
-using the assets
+using the resources
 and the use of those models
 provided that the resulting models
 and their outputs
@@ -343,8 +347,8 @@ might receive more specific instructions in two ways:
   statements of preference.
 
 For instance, a statement of preferences might indicate a preference
-to disallow a category of use for an asset.
-If arrangements, such as legal agreements, exist that explicitly permit the use of that asset,
+to disallow a category of use for a resource.
+If arrangements, such as legal agreements, exist that explicitly permit the use of that resource,
 those arrangements likely apply despite the existence of machine-readable statements of preference,
 unless the terms of the arrangement explicitly say otherwise.
 


### PR DESCRIPTION
This morning, I was thinking about the concerns that were raised yesterday about the use of the term "asset".   I think that someone had suggested replacing it with "artifact", which also doesn't seem exactly right.  What if we use "resource" instead?

I've also added RFC 3986 as an informative reference and noted in the Resource definition that this document uses a narrower sense of the term than RFC 3986's more general usage.