### PR TITLE
Restore "make available for use" in generative defintion

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -107,7 +107,7 @@ Declaring party:
 : The entity that expresses a preference with regards to an Asset.
 
 Generative AI model:
-: An AI model that is used or made available for use
+: An AI model that is used, or made available for use,
   in generating synthetic content
   in one or more modalities.
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -107,8 +107,8 @@ Declaring party:
 : The entity that expresses a preference with regards to an Asset.
 
 Generative AI model:
-: An AI model that is used
-  to generate synthetic content
+: An AI model that is used or made available for use
+  in generating synthetic content
   in one or more modalities.
 
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -106,6 +106,11 @@ Asset:
 Declaring party:
 : The entity that expresses a preference with regards to an Asset.
 
+Generative AI model:
+: An AI model that is used
+  to generate synthetic content
+  in one or more modalities.
+
 
 # Statements of Preference {#model}
 
@@ -218,9 +223,8 @@ implementations or their architecture.
 
 ## AI Model Training {#train-ai}
 
-Using an asset to modify the learned parameters of an AI model
-that is used
-to generate synthetic content in one or more modalities.
+Using an asset to modify the learned parameters
+of a generative AI model.
 
 ## Search {#search}
 


### PR DESCRIPTION
An improvement on #230 to include @kelleyk's original phrasing that covered open weight models.