### PR TITLE
Text changes discussed in London

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -243,7 +243,7 @@ Compliance with preferences regarding the use of assets
 in training of AI models
 also includes conveying the preferences
 associated with those assets
-along with that model.
+along with that model when it is distributed.
 
 # Vocabulary Definition {#vocab}
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -93,18 +93,24 @@ and {{format}} describes a way to serialize preferences into a string.
 Other means of association might be defined separately in the future.
 
 
-# Conventions and Definitions
+# Conventions and Definitions {#defs}
 
 {::boilerplate bcp14-tagged}
+
+*[asset]: #dfn-asset
+*[declaring party]: #dfn-decl-party
+*[generative AI model]: #dfn-genai
 
 This document uses the following terms:
 
 {: newline="true" spacing="compact"}
 Asset:
 : A digital file or stream of data, usually with associated metadata.
+  {: anchor="dfn-asset"}
 
 Declaring party:
 : The entity that expresses a preference with regards to an Asset.
+  {: anchor="dfn-decl-party"}
 
 Generative AI model:
 : An AI model that is used
@@ -118,6 +124,7 @@ Generative AI model:
   in classification, ranking, or scoring,
   even if those models generate rationales
   for the output of those operations.
+  {: anchor="dfn-genai"}
 
 
 # Statements of Preference {#model}
@@ -235,8 +242,7 @@ Using an asset to modify the learned parameters
 of a generative AI model.
 
 The training of models that are used
-to perform exclusively non-generative tasks,
-like ranking or classification,
+to perform exclusively non-generative tasks
 are not included in this category,
 even if the model is capable of generative tasks.
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -120,11 +120,11 @@ Generative AI model:
   Alternatively, an AI model that is made available for use
   to generate synthetic content
   in one or more modalities.
-  This definition does not include models that are used,
+  This definition does not include a model that is used,
   or made available for use,
-  in classification, ranking, or scoring,
-  even if those models generate rationales
-  for the output of those operations.
+  for classification, ranking, or scoring,
+  even where the model generates rationale
+  for its output.
   {: anchor="dfn-genai"}
 
 
@@ -251,14 +251,13 @@ even if the model is capable of generative tasks.
 ## AI Use {#ai-use}
 
 Use of an asset as input to a generative AI model,
-where the asset is not directly provided by the user\[,
-either as a URL or by supplying the asset itself\].
+where the asset is not directly provided by the user. [^249]
 
-<!-- Choose either the above or the below. -->
-
-\[If a system needs to perform inference
-in order to determine which asset to use,
-that does not qualify as a user directly providing the asset.\]
+[^249]: \[\[
+    [Issue 249](https://github.com/ietf-wg-aipref/drafts/issues/249)
+    addresses the question of whether "direct"
+    includes referencing `assets`, by URL or other means.
+    \]\]
 
 This does not include any use that is included
 in the AI Training usage category ({{train-ai}}).

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -266,7 +266,7 @@ of a generative AI model.
 
 The training of models that are used
 to perform exclusively non-generative tasks
-are not included in this category,
+is not included in this category,
 even if the model is capable of generative tasks.
 
 
@@ -307,7 +307,7 @@ This category of use only applies under the following conditions:
 This category does not include the use of assets
 to generate summaries.
 
-In displaying titles or excerpts from assets,
+Displaying titles or excerpts from assets,
 changes to improve accessibility,
 such as translation, transcription, or text-to-speech,
 are included in this category.

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -256,7 +256,7 @@ either as a URL or by supplying the asset itself\].
 
 <!-- Choose either the above or the below. -->
 
-\[If a system that needs to perform inference
+\[If a system needs to perform inference
 in order to determine which asset to use,
 that does not qualify as a user directly providing the asset.\]
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -226,6 +226,14 @@ implementations or their architecture.
 Using an asset to modify the learned parameters
 of a generative AI model.
 
+AI models can have multiple uses,
+some of which are not generative,
+even if the model might have those capabilities.
+The training of models that are used to perform non-generative tasks,
+like ranking or classification,
+are not included in this category.
+
+
 ## Search {#search}
 
 Use of an asset in an application

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -226,13 +226,10 @@ implementations or their architecture.
 Using an asset to modify the learned parameters
 of a generative AI model.
 
-AI models can have multiple uses,
-some of which are not generative,
-even if the model might have those capabilities.
 The training of models that are used
 to perform exclusively non-generative tasks,
 like ranking or classification,
-are not included in this category.
+are not included in this category, even if the model is capable of generative tasks.
 
 
 ## Search {#search}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -116,8 +116,8 @@ Generative AI model:
   \[This definition does not include models that are used,
   or made available for use,
   in classification, ranking, or scoring,
-  including the creation of minimal explanations
-  of the outputs of those operations.\]<!-- B -->
+  even if those models can generate rationale
+  for the output of those operations.\]<!-- B -->
 
 
 # Statements of Preference {#model}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -229,32 +229,6 @@ Whether and under which circumstances a preference is followed is outside the
 scope of this specification.
 
 
-## Documenting Conformance With This Specification {#decl}
-
-An entity that could act on preferences
-can document their conformance with this specification.
-
-In making such statements,
-it is not sufficient to simply declare support for
-with this specification.
-Support for this specification only includes
-the model for preferences ({{model}}),
-how preferences are understood and applied in general ({{usage}}),
-and maybe the exemplary serialization format ({{format}}).
-
-Statements about how an entity conforms with this specification
-ideally address:
-
-* which attachment mechanisms are understood,
-  which might include those defined in {{ATTACH}};
-
-* which of the vocabulary terms are understood,
-  either from {{vocab}} or extensions ({{vocab-extensions}}); and
-
-* for each vocabulary term,
-  it is also helpful to describe the circumstances under which
-  the entity will or will not follow expressed preferences.
-
 
 ## Communicating Preferences with Trained Models
 
@@ -268,30 +242,6 @@ in training of AI models
 also includes conveying the preferences
 associated with those assets
 along with that model.
-
-
-## Acquisition of Assets and Preferences {#acquisition-and-use}
-
-The fetching or receiving an asset
-is distinct from how that asset is subsequently used.
-
-Usage preferences do not apply
-to how assets are obtained.
-They only apply to how those assets are subsequently used;
-see {{applicability}}.
-
-Mechanisms exist --
-such as encryption, access controls,
-or the `Disallow` rules in "robots.txt" {{?ROBOTS=RFC9309}} --
-that might prevent an entity from acquiring an asset.
-Such mechanisms are independent of the ability of a declaring party
-to state their preferences about the use of assets.
-
-Where acquisition and use of assets occur at different times
-or in different parts of systems,
-retaining any usage preferences associated with those assets
-ensures that they are available to inform decisions about use.
-
 
 # Vocabulary Definition {#vocab}
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -113,8 +113,10 @@ Generative AI model:
   Alternatively, an AI model that is made available for use
   in generating synthetic content
   in one or more modalities.
-  \[This does not include classification, ranking, or scoring,
-  or the generation of brief explanations
+  \[This definition does not include models that are used,
+  or made available for use,
+  in classification, ranking, or scoring,
+  including the creation of minimal explanations
   of the outputs of those operations.\]<!-- B -->
 
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -280,7 +280,7 @@ where the asset is not directly provided by the user.
 [^249]:
     NOTE: [Issue 249](https://github.com/ietf-wg-aipref/drafts/issues/249)
     addresses the question of whether "direct"
-    includes referencing `assets`, by URL or other means.
+    includes referencing assets, by URL or other means.
 
 This does not include any use that is included
 in the AI Training usage category ({{train-ai}}).

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -245,6 +245,11 @@ also includes conveying the preferences
 associated with those assets
 along with that model when it is distributed.
 
+This requirement can be met by providing information
+on the full range of preferences that were associated with assets
+that were included in the training inputs
+or by indicating what sorts of uses are consistent with those preferences.
+
 # Vocabulary Definition {#vocab}
 
 [^vocab-consensus]
@@ -311,9 +316,6 @@ Displaying titles or excerpts from assets,
 changes to improve accessibility,
 such as translation, transcription, or text-to-speech,
 are included in this category.
-Such accessibility changes cannot generate new material,
-though additional changes could be acceptable
-based on other reasons.
 
 A preference to allow this category of use
 includes allowing any processing internal to the application

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -254,6 +254,8 @@ Use of an asset as input to a generative AI model,
 where the asset is not directly provided by the user\[,
 either as a URL or by supplying the asset itself\].
 
+<!-- Choose either the above or the below. -->
+
 \[If a system that needs to perform inference
 in order to determine which asset to use,
 that does not qualify as a user directly providing the asset.\]

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -98,6 +98,7 @@ Other means of association might be defined separately in the future.
 {::boilerplate bcp14-tagged}
 
 *[asset]: #dfn-asset
+*[assets]: #dfn-asset
 *[declaring party]: #dfn-decl-party
 *[generative AI model]: #dfn-genai
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -111,13 +111,13 @@ Generative AI model:
   to generate synthetic content
   in one or more modalities.
   Alternatively, an AI model that is made available for use
-  in generating synthetic content
+  to generate synthetic content
   in one or more modalities.
-  \[This definition does not include models that are used,
+  This definition does not include models that are used,
   or made available for use,
   in classification, ranking, or scoring,
   even if those models can generate rationale
-  for the output of those operations.\]<!-- B -->
+  for the output of those operations.
 
 
 # Statements of Preference {#model}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -269,6 +269,29 @@ associated with those assets
 along with that model.
 
 
+## Acquisition of Assets and Preferences {#acquisition-and-use}
+
+The fetching or receiving an asset
+is distinct from how that asset is subsequently used.
+
+Usage preferences do not apply
+to how assets are obtained.
+They only apply to how those assets are subsequently used;
+see {{applicability}}.
+
+Mechanisms exist --
+such as encryption, access controls,
+or the `Disallow` rules in "robots.txt" {{?ROBOTS=RFC9309}} --
+that might prevent an entity from acquiring an asset.
+Such mechanisms are independent of the ability of a declaring party
+to state their preferences about the use of assets.
+
+Where acquisition and use of assets occur at different times
+or in different parts of systems,
+retaining any usage preferences associated with those assets
+ensures that they are available to inform decisions about use.
+
+
 # Vocabulary Definition {#vocab}
 
 <cref>

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -116,7 +116,7 @@ Generative AI model:
   This definition does not include models that are used,
   or made available for use,
   in classification, ranking, or scoring,
-  even if those models can generate rationale
+  even if those models generate rationales
   for the output of those operations.
 
 
@@ -229,7 +229,7 @@ of assets.  The definitions seek to avoid describing internal details of
 implementations or their architecture.
 
 
-## AI Model Training {#train-ai}
+## AI Training {#train-ai}
 
 Using an asset to modify the learned parameters
 of a generative AI model.
@@ -410,7 +410,7 @@ Each usage category in the vocabulary ({{vocab}}) is mapped to a short textual l
 
 | Category                    | Label       | Reference       |
 |:----------------------------|:------------|:----------------|
-| AI Model Training           | train-ai    | {{train-ai}}    |
+| AI Training                 | train-ai    | {{train-ai}}    |
 | AI Use                      | ai-use      | {{ai-use}}      |
 | Search                      | search      | {{search}}      |
 {: #t-category-labels title="Mappings for Categories"}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -130,9 +130,10 @@ Generative AI model:
 
 # Statements of Preference {#model}
 
-<cref>
+[^model-consensus]
+
+[^model-consensus]:
     NOTE: This section does not yet have consensus; see "Note to Readers" above.
-</cref>
 
 The vocabulary is a set of categories,
 each of which is defined to cover a class of usage for assets.
@@ -232,10 +233,11 @@ scope of this specification.
 
 ## Communicating Preferences with Trained Models
 
-<cref>
+[^245]
+
+[^245]:
     NOTE: [Issue 245](https://github.com/ietf-wg-aipref/drafts/issues/245)
     is open to track whether this section is included or not.
-</cref>
 
 Compliance with preferences regarding the use of assets
 in training of AI models
@@ -245,9 +247,10 @@ along with that model.
 
 # Vocabulary Definition {#vocab}
 
-<cref>
+[^vocab-consensus]
+
+[^vocab-consensus]:
     NOTE: This section does not yet have consensus; see "Note to Readers" above.
-</cref>
 
 This section defines the categories of use in the vocabulary.
 
@@ -272,11 +275,12 @@ even if the model is capable of generative tasks.
 Use of an asset as input to a generative AI model,
 where the asset is not directly provided by the user.
 
-<cref>
+[^249]
+
+[^249]:
     NOTE: [Issue 249](https://github.com/ietf-wg-aipref/drafts/issues/249)
     addresses the question of whether "direct"
     includes referencing `assets`, by URL or other means.
-</cref>
 
 This does not include any use that is included
 in the AI Training usage category ({{train-ai}}).

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -352,15 +352,12 @@ This category of use only applies under the following conditions:
 This category does not include the use of assets
 to generate summaries.
 
-Non-substantive changes to the presentation
-of titles or excerpts from assets
-are included for the purposes of accessibility.
-Translation, transcription, or text-to-speech
-are examples of non-substantive changes
-that could help users understand what is being presented.
-Where existing controls restrict presentation of these items,
-such as limitations on snippet size,
-those apply before any changes.
+In displaying titles or excerpts from assets,
+changes to improve accessibility,
+such as translation, transcription, or text-to-speech,
+are included in this category.
+These changes must not involve the generation of new material,
+though such changes may be permissible for other reasons.
 
 A preference to allow this category of use
 includes allowing any processing internal to the application

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -108,8 +108,10 @@ Declaring party:
 
 Generative AI model:
 : An AI model that is used
-  \[, or made available for use,]<!-- A -->
   to generate synthetic content
+  in one or more modalities.
+  Alternatively, an AI model that is made available for use
+  in generating synthetic content
   in one or more modalities.
   \[This does not include classification, ranking, or scoring,
   or the generation of brief explanations

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -130,7 +130,9 @@ Generative AI model:
 
 # Statements of Preference {#model}
 
-NOTE: This section does not yet have consensus; see "Note to Readers" above.
+<cref>
+    NOTE: This section does not yet have consensus; see "Note to Readers" above.
+</cref>
 
 The vocabulary is a set of categories,
 each of which is defined to cover a class of usage for assets.
@@ -226,9 +228,52 @@ Whether and under which circumstances a preference is followed is outside the
 scope of this specification.
 
 
+## Documenting Conformance With This Specification {#decl}
+
+An entity that could act on preferences
+can document their conformance with this specification.
+
+In making such statements,
+it is not sufficient to simply declare support for
+with this specification.
+Support for this specification only includes
+the model for preferences ({{model}}),
+how preferences are understood and applied in general ({{usage}}),
+and maybe the exemplary serialization format ({{format}}).
+
+Statements about how an entity conforms with this specification
+ideally address:
+
+* which attachment mechanisms are understood,
+  which might include those defined in {{ATTACH}};
+
+* which of the vocabulary terms are understood,
+  either from {{vocab}} or extensions ({{extension}}); and
+
+* for each vocabulary term,
+  it is also helpful to describe the circumstances under which
+  the entity will or will not follow expressed preferences.
+
+
+## Communicating Preferences with Trained Models
+
+<cref>
+    NOTE: [Issue 245](https://github.com/ietf-wg-aipref/drafts/issues/245)
+    is open to track whether this section is included or not.
+</cref>
+
+Compliance with preferences regarding the use of assets
+in training of AI models
+also includes conveying the preferences
+associated with those assets
+along with that model.
+
+
 # Vocabulary Definition {#vocab}
 
-NOTE: This section does not yet have consensus; see "Note to Readers" above.
+<cref>
+    NOTE: This section does not yet have consensus; see "Note to Readers" above.
+</cref>
 
 This section defines the categories of use in the vocabulary.
 
@@ -251,13 +296,13 @@ even if the model is capable of generative tasks.
 ## AI Use {#ai-use}
 
 Use of an asset as input to a generative AI model,
-where the asset is not directly provided by the user. [^249]
+where the asset is not directly provided by the user.
 
-[^249]: \[\[
-    [Issue 249](https://github.com/ietf-wg-aipref/drafts/issues/249)
+<cref>
+    NOTE: [Issue 249](https://github.com/ietf-wg-aipref/drafts/issues/249)
     addresses the question of whether "direct"
     includes referencing `assets`, by URL or other means.
-    \]\]
+</cref>
 
 This does not include any use that is included
 in the AI Training usage category ({{train-ai}}).

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -181,7 +181,8 @@ as it relates to understanding what the preferences for a given asset are
 A recipient can only apply preferences it understands.
 Recipients that implement this specification
 will understand the vocabulary terms defined in {{vocab}},
-but they might not understand extensions; see {{extension}}.
+but they might not understand terms defined in extensions;
+see {{vocab-extensions}}.
 
 A recipient can only understand preferences expressed
 through mechanisms it has implemented.
@@ -248,7 +249,7 @@ ideally address:
   which might include those defined in {{ATTACH}};
 
 * which of the vocabulary terms are understood,
-  either from {{vocab}} or extensions ({{extension}}); and
+  either from {{vocab}} or extensions ({{vocab-extensions}}); and
 
 * for each vocabulary term,
   it is also helpful to describe the circumstances under which
@@ -380,7 +381,7 @@ including AI Training ({{train-ai}})
 and AI Use ({{ai-use}}).
 
 
-## Vocabulary Extensions {#vocab-extension}
+## Vocabulary Extensions {#vocab-extensions}
 
 Extensions to this vocabulary are defined
 in a standards-track RFC that updates this document.
@@ -525,13 +526,13 @@ so any format that uses strings needs to encode strings first.
 Again, this process can use ASCII or UTF-8.
 
 
-## Syntax Extensions {#extension}
+## Syntax Extensions {#syntax-extensions}
 
 There are two ways by which this syntax might be extended:
 the addition of new labels and the addition of parameters.
 
 New labels might be defined to correspond to new usage categories.
-{{vocab-extension}} addresses the considerations for defining new categories.
+{{vocab-extensions}} addresses the considerations for defining new categories.
 
 New labels might also be defined for other types of extension
 that do not assign a preference to a usage category.
@@ -626,7 +627,7 @@ train-ai;has;parameters="?";
 ~~~
 
 
-## Alternative Formats {#mapping}
+# Alternative Formats {#mapping}
 
 The format defined in this document
 is only an exemplary way to represent preferences.
@@ -636,7 +637,8 @@ can be used without this serialization.
 Any alternative format needs to define the mapping
 both from that format to the model used in this document
 and from the model to the alternative format.
-This includes any potential for extensions ({{extension}}).
+This includes any potential for extensions to the vocabulary;
+see {{vocab-extensions}}.
 
 The mapping between the data model and the alternative format
 does not need to be complete,

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -251,7 +251,6 @@ even if the model is capable of generative tasks.
 ## AI Use {#ai-use}
 
 Use of an asset as input to a generative AI model,
-\[as the result of a request\]<!-- C -->
 which does not alter the learned parameters of the model.
 
 This does not include any use that is included

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -365,16 +365,17 @@ those apply before any changes.
 A preference to allow this category of use
 includes allowing any processing internal to the application
 that is performed on assets.
-Allowing this use is conditional on the outputs of any processing
+Allowing this processing is conditional on the outputs of any processing
 being exclusively used by the search application
 according to the other restrictions in this section.
-That includes the training of AI models
+Allowed processing therefore includes the training of AI models
 using the assets
 and the use of those models
 provided that the resulting models
 and their outputs
 are used exclusively
-in ways that meet the above conditions.
+in ways that meet the above conditions
+regarding referencing and excerpts.
 
 This category of use overrides any usage
 that falls into other categories,

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -229,7 +229,8 @@ of a generative AI model.
 AI models can have multiple uses,
 some of which are not generative,
 even if the model might have those capabilities.
-The training of models that are used to perform non-generative tasks,
+The training of models that are used
+to perform exclusively non-generative tasks,
 like ranking or classification,
 are not included in this category.
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -229,7 +229,8 @@ of a generative AI model.
 The training of models that are used
 to perform exclusively non-generative tasks,
 like ranking or classification,
-are not included in this category, even if the model is capable of generative tasks.
+are not included in this category,
+even if the model is capable of generative tasks.
 
 
 ## Search {#search}

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -108,8 +108,12 @@ Declaring party:
 
 Generative AI model:
 : An AI model that is used
+  \[, or made available for use,]<!-- A -->
   to generate synthetic content
   in one or more modalities.
+  \[This does not include classification, ranking, or scoring,
+  or the generation of brief explanations
+  of the outputs of those operations.\]<!-- B -->
 
 
 # Statements of Preference {#model}
@@ -233,6 +237,16 @@ are not included in this category,
 even if the model is capable of generative tasks.
 
 
+## AI Use {#ai-use}
+
+Use of an asset as input to a generative AI model,
+\[as the result of a request\]<!-- C -->
+which does not alter the learned parameters of the model.
+
+This does not include any use that is included
+in the AI Training usage category ({{train-ai}}).
+
+
 ## Search {#search}
 
 Use of an asset in an application
@@ -277,6 +291,11 @@ provided that the resulting models
 and their outputs
 are used exclusively
 in ways that meet the above conditions.
+
+This category of use overrides any usage
+that falls into other categories,
+including AI Training ({{train-ai}})
+and AI Use ({{ai-use}}).
 
 
 ## Vocabulary Extensions {#vocab-extension}
@@ -388,6 +407,7 @@ Each usage category in the vocabulary ({{vocab}}) is mapped to a short textual l
 | Category                    | Label       | Reference       |
 |:----------------------------|:------------|:----------------|
 | AI Model Training           | train-ai    | {{train-ai}}    |
+| AI Use                      | ai-use      | {{ai-use}}      |
 | Search                      | search      | {{search}}      |
 {: #t-category-labels title="Mappings for Categories"}
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -277,7 +277,7 @@ even if the model is capable of generative tasks.
 
 ## AI Use {#ai-use}
 
-Use of an asset as input to a generative AI model,
+Using an asset as input to a generative AI model,
 where the asset is not directly provided by the user.
 
 [^249]
@@ -293,7 +293,7 @@ in the AI Training usage category ({{train-ai}}).
 
 ## Search {#search}
 
-Use of an asset in an application
+Using an asset in an application
 where the primary purpose of the application
 is to select assets
 and direct users to the location of those assets.

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -307,8 +307,9 @@ In displaying titles or excerpts from assets,
 changes to improve accessibility,
 such as translation, transcription, or text-to-speech,
 are included in this category.
-These changes must not involve the generation of new material,
-though such changes may be permissible for other reasons.
+Such accessibility changes cannot generate new material,
+though additional changes could be acceptable
+based on other reasons.
 
 A preference to allow this category of use
 includes allowing any processing internal to the application

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -106,6 +106,11 @@ Asset:
 Declaring party:
 : The entity that expresses a preference with regards to an Asset.
 
+Generative AI model:
+: An AI model that is used
+  to generate synthetic content
+  in one or more modalities.
+
 
 # Statements of Preference {#model}
 
@@ -218,9 +223,8 @@ implementations or their architecture.
 
 ## AI Model Training {#train-ai}
 
-Using an asset to modify the learned parameters of an AI model
-that is used
-to generate synthetic content in one or more modalities.
+Using an asset to modify the learned parameters
+of a generative AI model.
 
 ## Search {#search}
 

--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -251,7 +251,12 @@ even if the model is capable of generative tasks.
 ## AI Use {#ai-use}
 
 Use of an asset as input to a generative AI model,
-which does not alter the learned parameters of the model.
+where the asset is not directly provided by the user\[,
+either as a URL or by supplying the asset itself\].
+
+\[If a system that needs to perform inference
+in order to determine which asset to use,
+that does not qualify as a user directly providing the asset.\]
 
 This does not include any use that is included
 in the AI Training usage category ({{train-ai}}).


### PR DESCRIPTION
This collects a bunch of changes from the discussion in London.

Of note is:

* the new definition of "generative AI model" and the specific exclusions we have in that definition around classifiers
* the revisions to the "AI Training" category of use
   * The expectation is that this doesn't change the meaning of the category at all, just adds clarity.
* the addition of the "AI Use" category
    * The name of this category likely needs to be refined, but the request is to look at the meaning.
    * There is a clear note here about the "directly provided by a user" language and what that means in relation to providing a URL.  This explicitly references an open issue on this point.
* text on including indications about preferences associated with assets in model documentation, which also has an issue reference as this was controversial

There are some additional minor edits, but those are the bulk of the change.

The commit history here is a little fragmented.  Many of the changes were iterated upon in multiple phases.  In reviewing this, please look at the final product.

A rendered version of this can be viewed at https://ietf-wg-aipref.github.io/drafts/post-london/draft-ietf-aipref-vocab.html