### PR TITLE
Distinguish acquisition and use

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -245,6 +245,30 @@ also includes conveying the preferences
 associated with those assets
 along with that model.
 
+
+## Acquisition of Assets and Preferences {#acquisition-and-use}
+
+The fetching or receiving an asset
+is distinct from how that asset is subsequently used.
+
+Usage preferences do not apply
+to how assets are obtained.
+They only apply to how those assets are subsequently used;
+see {{applicability}}.
+
+Mechanisms exist --
+such as encryption, access controls,
+or the `Disallow` rules in "robots.txt" {{?ROBOTS=RFC9309}} --
+that might prevent an entity from acquiring an asset.
+Such mechanisms are independent of the ability of a declaring party
+to state their preferences about the use of assets.
+
+Where acquisition and use of assets occur at different times
+or in different parts of systems,
+retaining any usage preferences associated with those assets
+ensures that they are available to inform decisions about use.
+
+
 # Vocabulary Definition {#vocab}
 
 [^vocab-consensus]


### PR DESCRIPTION
Any system of preferences like what we have naturally has no guards on assets being acquired.  The preferences that declaring parties express only apply to how the asset is subsequently used.

This attempts to document that more clearly.  It also highlights the need to retain preferences along with assets if their use does not immediately follow acquisition (which is likely to be the typical case, with immediate use being the abnormal case).

This doesn't address #246, but it creates a place where that might be more naturally addressed, by saying that intermediate forms or transformations of assets (such as embeddings created from assets) might also need to retain preferences if they might subsequently be used.

Closes #167.
Closes #193.