### PR TITLE
Transformations don't erase preferences

### DIFF
--- a/draft-ietf-aipref-vocab.md
+++ b/draft-ietf-aipref-vocab.md
@@ -268,6 +268,12 @@ or in different parts of systems,
 retaining any usage preferences associated with those assets
 ensures that they are available to inform decisions about use.
 
+Retaining preferences with assets that are transformed
+into an alternative format prior to their use,
+including the creation of embeddings or other simplified forms,
+also provides an opportunity to apply preferences
+at the point of use.
+
 
 # Vocabulary Definition {#vocab}
 


### PR DESCRIPTION
This is an alternative spelling to #240 that builds on #252.

Given that #252 adds text that says something about retaining preferences obtained during acquisition until you can make a decision about them at the point of use, the same thing applies when the asset gets transformed along the way.

Closes #246.